### PR TITLE
Implement forwarding of login hint to auth URL

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -10,3 +10,5 @@
 #
 #- name: John Smith
 #  email: foo@bar.com
+- name: Lennart Schoch
+  email: lennartschoch@protonmail.com

--- a/pkg/authz/config.go
+++ b/pkg/authz/config.go
@@ -59,7 +59,8 @@ type PolicyConfig struct {
 	ValidateSourceAddress bool `json:"validate_source_address,omitempty" xml:"validate_source_address,omitempty" yaml:"validate_source_address,omitempty"`
 	// Pass claims from JWT token via HTTP X- headers.
 	PassClaimsWithHeaders bool `json:"pass_claims_with_headers,omitempty" xml:"pass_claims_with_headers,omitempty" yaml:"pass_claims_with_headers,omitempty"`
-
+	// Validate the login hint which can be passed to the auth provider
+	LoginHintValidators []string `json:"login_hint_validators,omitempty" xml:"login_hint_validators,omitempty" yaml:"login_hint_validators,omitempty"`
 	// Holds raw crypto configuration.
 	cryptoRawConfigs []string
 	// Holds raw identity provider configuration.

--- a/pkg/authz/handlers/redirect.go
+++ b/pkg/authz/handlers/redirect.go
@@ -147,5 +147,12 @@ func configureRedirect(w http.ResponseWriter, r *http.Request, rr *requests.Auth
 		rr.Redirect.Separator = "&"
 	}
 
+	if rr.Redirect.LoginHint != "" {
+		loginHint := rr.Redirect.LoginHint
+		escapedLoginHint := url.QueryEscape(loginHint)
+		rr.Redirect.AuthURL = rr.Redirect.AuthURL + rr.Redirect.Separator + "login_hint" + "=" + escapedLoginHint
+		rr.Redirect.Separator = "&"
+	}
+
 	return
 }

--- a/pkg/errors/common.go
+++ b/pkg/errors/common.go
@@ -134,4 +134,5 @@ const (
 
 	// InstanceManager errors.
 	ErrInstanceManagerValidate StandardError = "instance %q validation failed: %v"
+	ErrInvalidLoginHint        StandardError = "login_hint query parameter is not in a valid format"
 )

--- a/pkg/util/validate/login_hint.go
+++ b/pkg/util/validate/login_hint.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"github.com/greenpau/go-authcrunch/pkg/errors"
+	"net/mail"
+	"regexp"
+)
+
+// LoginHint verifies if the provided login_hint argument is valid
+func LoginHint(loginHint string, validators []string) error {
+
+	for _, validator := range validators {
+		switch validator {
+		case "email":
+			if _, err := mail.ParseAddress(loginHint); err == nil {
+				return nil
+			}
+		case "phone":
+			regex, _ := regexp.Compile("^[0-9\\-+\\s]+$")
+			if match := regex.MatchString(loginHint); match == true {
+				return nil
+			}
+		case "alphanumeric":
+			regex, _ := regexp.Compile("^[a-zA-Z0-9\\-._!~*'()]+$")
+			if match := regex.MatchString(loginHint); match == true {
+				return nil
+			}
+		}
+	}
+	return errors.ErrInvalidLoginHint
+}

--- a/pkg/util/validate/login_hint_test.go
+++ b/pkg/util/validate/login_hint_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"github.com/greenpau/go-authcrunch/internal/tests"
+	"github.com/greenpau/go-authcrunch/pkg/errors"
+	"testing"
+)
+
+func TestLoginHint(t *testing.T) {
+	var testcases = []struct {
+		name       string
+		loginHint  string
+		validators []string
+		shouldErr  bool
+		err        error
+	}{
+		{
+			name:       "doesn't return an error if the provided login_hint is a valid email",
+			loginHint:  "foo@bar.com",
+			validators: []string{"email"},
+			shouldErr:  false,
+			err:        nil,
+		},
+		{
+			name:       "returns an error if the provided login_hint has an invalid domain",
+			loginHint:  "foo@",
+			validators: []string{"email"},
+			shouldErr:  true,
+			err:        errors.ErrInvalidLoginHint,
+		},
+		{
+			name:       "returns an error if the provided login_hint has an invalid domain",
+			loginHint:  "foo@().com",
+			validators: []string{"email"},
+			shouldErr:  true,
+			err:        errors.ErrInvalidLoginHint,
+		},
+		{
+			name:       "doesn't return an error if the provided login_hint is a valid phone number",
+			loginHint:  "+1-555-55 55",
+			validators: []string{"phone"},
+			shouldErr:  false,
+			err:        nil,
+		},
+		{
+			name:       "returns an error if the provided login_hint is not a valid phone number",
+			loginHint:  ".5dsa-dasdas55",
+			validators: []string{"phone"},
+			shouldErr:  true,
+			err:        errors.ErrInvalidLoginHint,
+		},
+		{
+			name:       "doesn't return an error if the provided login_hint is a valid alphanumeric string",
+			loginHint:  "foobar",
+			validators: []string{"alphanumeric"},
+			shouldErr:  false,
+			err:        nil,
+		},
+		{
+			name:       "returns an error if the provided login_hint is not a valid alphanumeric string",
+			loginHint:  "!^$^#&$&abc",
+			validators: []string{"alphanumeric"},
+			shouldErr:  true,
+			err:        errors.ErrInvalidLoginHint,
+		},
+		{
+			name:       "doesn't return an error if the provided login_hint matches one of the validators",
+			loginHint:  "+1-555-55 55",
+			validators: []string{"email", "phone"},
+			shouldErr:  false,
+			err:        nil,
+		},
+		{
+			name:       "returns an error if the provided login_hint doesn't match any validator",
+			loginHint:  "ma!e^",
+			validators: []string{"email", "phone", "alphanumeric"},
+			shouldErr:  true,
+			err:        errors.ErrInvalidLoginHint,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := LoginHint(tc.loginHint, tc.validators)
+
+			if tests.EvalErrWithLog(t, err, nil, tc.shouldErr, tc.err, []string{}) {
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR migrates the changes made to caddy-authorize in [this PR](https://github.com/greenpau/caddy-authorize/pull/95) to the new repo.

Functionality-wise it should be absolutely the same, let me know what you think!