### PR TITLE
Added OID (objectidentifier) to SAML to allow AzureID of user

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -10,5 +10,5 @@
 #
 #- name: John Smith
 #  email: foo@bar.com
-- name: Lennart Schoch
-  email: lennartschoch@protonmail.com
+- name: Caleb Coverdale
+  email: calebcoverdale@me.com

--- a/pkg/authn/backends/saml/authenticate.go
+++ b/pkg/authn/backends/saml/authenticate.go
@@ -17,10 +17,11 @@ package saml
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/greenpau/go-authcrunch/pkg/requests"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/greenpau/go-authcrunch/pkg/requests"
 
 	"go.uber.org/zap"
 )
@@ -119,6 +120,10 @@ func (b *Backend) Authenticate(r *requests.Request) error {
 			case strings.HasSuffix(attrEntry.Name, "identity/claims/name"):
 				if attrEntry.Values[0].Value != "" {
 					m["sub"] = attrEntry.Values[0].Value
+				}
+			case strings.HasSuffix(attrEntry.Name, "identity/claims/objectidentifier"):
+				if attrEntry.Values[0].Value != "" {
+					m["oid"] = attrEntry.Values[0].Value
 				}
 			case strings.HasSuffix(attrEntry.Name, "Attributes/Role"):
 				roles := []string{}


### PR DESCRIPTION
Hello! 

I have added the "identity/claims/objectidentifier" claim to SAML to allow the AzureID of a user to passthrough on the token. 

I have added in the consent document, and put it all into one commit. 