### PR TITLE
oauth2: remove email claim check

### DIFF
--- a/pkg/authn/backends/oauth2/validator.go
+++ b/pkg/authn/backends/oauth2/validator.go
@@ -86,10 +86,6 @@ func (b *Backend) validateAccessToken(state string, data map[string]interface{})
 		return nil, errors.ErrBackendOAuthNonceValidationFailed.WithArgs(b.Config.IdentityTokenName, err)
 	}
 
-	if _, exists := claims["email"]; !exists {
-		return nil, errors.ErrBackendOAuthEmailNotFound.WithArgs(b.Config.IdentityTokenName)
-	}
-
 	m := make(map[string]interface{})
 	for _, k := range tokenFields {
 		if _, exists := claims[k]; !exists {


### PR DESCRIPTION
The email claim is not necessary for OIDC.
If only openid scope is used (without email, profile, etc.) the email claim will not be available.
Instead, it would make more sense to check for "sub" but this will work without that check for now.

The email claim could later be added by using a transform directive (`action add email {claims.sub}@{claims.realm}`)
I've tested this manually and it works for our use case, allowing us to resolve the final issue with this plugin.

This won't break existing configuration as this is only a validation step.