### PR TITLE
Set CodeQL options for codeql-action/analyze

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,8 +30,6 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
-      env:
-        CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"interpret-results":["--max-paths",0]}}'
       with:
         languages: ${{ matrix.language }}
         debug: true
@@ -41,6 +39,8 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      env:
+        CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"interpret-results":["--max-paths",0]}}'      
       with:
         #  upload: false
         wait-for-processing: true


### PR DESCRIPTION
@greenpau I think the special environment variable should be set for the `codeql-action/analyze` step because the `codeql database interpret-results` command is ran as part of that step.