### PR TITLE
Sanitize referrer url on Generic html template

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -14,3 +14,5 @@
   email: lennartschoch@protonmail.com
 - name: Antonio Cunha
   email: aj.20.cunha@gmail.com
+- name: Pedro Flores
+  email: pedro_flores_16@hotmail.com

--- a/pkg/authn/respond_http.go
+++ b/pkg/authn/respond_http.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 )
 
@@ -92,6 +93,13 @@ func (p *Portal) handleHTTPErrorWithLog(ctx context.Context, w http.ResponseWrit
 	return p.handleHTTPError(ctx, w, r, rr, code)
 }
 
+func sanitizeUrl(urlToSanitize string) string {
+	r := regexp.MustCompile("(&|<|>|\"|')")
+	return r.ReplaceAllStringFunc(urlToSanitize, func(s string) string {
+		return url.QueryEscape(s)
+	})
+}
+
 func (p *Portal) handleHTTPError(ctx context.Context, w http.ResponseWriter, r *http.Request, rr *requests.Request, code int) error {
 	p.disableClientCache(w)
 	resp := p.ui.GetArgs()
@@ -111,7 +119,7 @@ func (p *Portal) handleHTTPError(ctx context.Context, w http.ResponseWriter, r *
 		resp.Data["go_back_url"] = rr.Response.RedirectURL
 	} else {
 		if r.Referer() != "" {
-			resp.Data["go_back_url"] = r.Referer()
+			resp.Data["go_back_url"] = sanitizeUrl(r.Referer())
 		} else {
 			resp.Data["go_back_url"] = "/"
 		}

--- a/pkg/authn/respond_http.go
+++ b/pkg/authn/respond_http.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"regexp"
 	"strings"
 )
 
@@ -93,13 +92,6 @@ func (p *Portal) handleHTTPErrorWithLog(ctx context.Context, w http.ResponseWrit
 	return p.handleHTTPError(ctx, w, r, rr, code)
 }
 
-func sanitizeUrl(urlToSanitize string) string {
-	r := regexp.MustCompile("(&|<|>|\"|')")
-	return r.ReplaceAllStringFunc(urlToSanitize, func(s string) string {
-		return url.QueryEscape(s)
-	})
-}
-
 func (p *Portal) handleHTTPError(ctx context.Context, w http.ResponseWriter, r *http.Request, rr *requests.Request, code int) error {
 	p.disableClientCache(w)
 	resp := p.ui.GetArgs()
@@ -119,7 +111,7 @@ func (p *Portal) handleHTTPError(ctx context.Context, w http.ResponseWriter, r *
 		resp.Data["go_back_url"] = rr.Response.RedirectURL
 	} else {
 		if r.Referer() != "" {
-			resp.Data["go_back_url"] = sanitizeUrl(r.Referer())
+			resp.Data["go_back_url"] = util.SanitizeUrlForInvalidCharacters(r.Referer())
 		} else {
 			resp.Data["go_back_url"] = "/"
 		}

--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -27,29 +27,28 @@ import (
 	"testing"
 )
 
-type CustomResponseWriter struct {
+type customResponseWriter struct {
 	body       []byte
 	statusCode int
 	header     http.Header
 }
 
-func NewCustomResponseWriter() *CustomResponseWriter {
-	return &CustomResponseWriter{
+func NewCustomResponseWriter() *customResponseWriter {
+	return &customResponseWriter{
 		header: http.Header{},
 	}
 }
 
-func (w *CustomResponseWriter) Header() http.Header {
+func (w *customResponseWriter) Header() http.Header {
 	return w.header
 }
 
-func (w *CustomResponseWriter) Write(b []byte) (int, error) {
+func (w *customResponseWriter) Write(b []byte) (int, error) {
 	w.body = b
-	// implement it as per your requirement
 	return 0, nil
 }
 
-func (w *CustomResponseWriter) WriteHeader(statusCode int) {
+func (w *customResponseWriter) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 }
 

--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"github.com/greenpau/go-authcrunch/internal/tests"
 	"github.com/greenpau/go-authcrunch/pkg/authn/cookie"
+	"github.com/greenpau/go-authcrunch/pkg/authn/ui"
 	"github.com/greenpau/go-authcrunch/pkg/requests"
 	"go.uber.org/zap"
 	"net/http"
@@ -26,17 +27,31 @@ import (
 	"testing"
 )
 
-type mockResponseWriter struct{}
-
-func (w *mockResponseWriter) Header() http.Header {
-	return http.Header{}
+type CustomResponseWriter struct {
+	body       []byte
+	statusCode int
+	header     http.Header
 }
 
-func (w *mockResponseWriter) Write([]byte) (int, error) {
+func NewCustomResponseWriter() *CustomResponseWriter {
+	return &CustomResponseWriter{
+		header: http.Header{},
+	}
+}
+
+func (w *CustomResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *CustomResponseWriter) Write(b []byte) (int, error) {
+	w.body = b
+	// implement it as per your requirement
 	return 0, nil
 }
 
-func (w *mockResponseWriter) WriteHeader(int) {}
+func (w *CustomResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
 
 func TestInjectRedirectURL(t *testing.T) {
 
@@ -58,10 +73,45 @@ func TestInjectRedirectURL(t *testing.T) {
 		}
 		request := requests.NewRequest()
 
-		p.injectRedirectURL(context.Background(), &mockResponseWriter{}, &r, request)
+		p.injectRedirectURL(context.Background(), NewCustomResponseWriter(), &r, request)
 
 		cookieParts := strings.Split(request.Response.RedirectURL, ";")
 		tests.EvalObjectsWithLog(t, "redirect url", "AUTHP_REDIRECT_URL=https://foo.bar/redir", cookieParts[0], []string{})
+	})
+}
 
+func TestRefererSanitization(t *testing.T) {
+	t.Run("should sanitize referral url if its malformed in a way that is intended to cause a XSS", func(t *testing.T) {
+		reqURL := url.URL{
+			Scheme:   "https",
+			Host:     "foo.bar",
+			Path:     "/myPage",
+			RawQuery: "redirect_url=https%3A%2F%2Ffoo.bar%2Fredir",
+		}
+		r := http.Request{URL: &reqURL, Method: "GET"}
+		r.Header = make(http.Header)
+		maliciousUrl := "https://www.google.com/search?hl=en&q=testing'\"()&%<acx><ScRiPt >alert(9854)</ScRiPt>"
+		r.Header.Set("Referer", maliciousUrl)
+		f, _ := cookie.NewFactory(nil)
+		uiFactory := ui.NewFactory()
+		p := Portal{
+			config: &PortalConfig{
+				Name: "somePortal",
+				UI: &ui.Parameters{
+					Theme: "",
+				},
+			},
+			logger: zap.L(),
+			cookie: f,
+			ui:     uiFactory,
+		}
+		_ = p.configureUserInterface()
+		request := requests.NewRequest()
+		rw := NewCustomResponseWriter()
+
+		_ = p.handleHTTPError(context.Background(), rw, &r, request, 404)
+		rb := string(rw.body)
+
+		tests.EvalObjectsWithLog(t, "sanitized url", true, strings.Contains(rb, "https://www.google.com/search?hl=en%26q=testing%27%22()%26%%3Cacx%3E%3CScRiPt %3Ealert(9854)%3C/ScRiPt%3E"), []string{})
 	})
 }

--- a/pkg/util/sanitizer.go
+++ b/pkg/util/sanitizer.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// SanitizeUrlForInvalidCharacters escapes some invalid characters than can allow for Cross Site Scripting
+func SanitizeUrlForInvalidCharacters(urlToSanitize string) string {
+	r := regexp.MustCompile("[&|<|>|\"|']")
+	return r.ReplaceAllStringFunc(urlToSanitize, func(s string) string {
+		return url.QueryEscape(s)
+	})
+}

--- a/pkg/util/sanitizer_test.go
+++ b/pkg/util/sanitizer_test.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"github.com/greenpau/go-authcrunch/internal/tests"
+	"testing"
+)
+
+func TestUrlSanitization(t *testing.T) {
+	t.Run("should sanitize  url if its malformed in a way that is intended to cause a XSS", func(t *testing.T) {
+		maliciousUrl := "https://www.google.com/search?hl=en&q=testing'\"()&%<acx><ScRiPt >alert(9854)</ScRiPt>"
+
+		sanitizedUrl := SanitizeUrlForInvalidCharacters(maliciousUrl)
+
+		tests.EvalObjectsWithLog(t, "sanitized url", "https://www.google.com/search?hl=en%26q=testing%27%22()%26%%3Cacx%3E%3CScRiPt %3Ealert(9854)%3C/ScRiPt%3E", sanitizedUrl, []string{})
+	})
+}


### PR DESCRIPTION
Hello.

During some testing we discovered that calling the `/auth/oauth2` endpoint with a malicious `Referrer` header ends up in being able to inject JS code into the rendered template, as an example:

GET /auth/oauth2/ HTTP/2
Host: localhost:8000
Referrer: https://www.google.com/search?hl=en&q=testing'"()&%<acx><ScRiPt >alert(9854)</ScRiPt>
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4298.0 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,/;q=0.8
Accept-Encoding: gzip,deflate

Inputting that referrer into the link href will escape the quotes there and inject the script part into the HTML, when it's rendered it will be executed.

The fix follows the recommendation from [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding) and thus we are replacing those characters for their HTML encoded version. 