### PR TITLE
When query parameter is disabled redirect stop working

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -16,3 +16,5 @@
   email: aj.20.cunha@gmail.com
 - name: Pedro Flores
   email: pedro_flores_16@hotmail.com
+- name: Daniel Branco
+  email: dbranco@gmail.com

--- a/pkg/authz/handlers/redirect.go
+++ b/pkg/authz/handlers/redirect.go
@@ -102,6 +102,8 @@ func configureRedirect(w http.ResponseWriter, r *http.Request, rr *requests.Auth
 		return
 	}
 
+	rr.Redirect.Enabled = true
+
 	if rr.Redirect.QueryDisabled {
 		return
 	}
@@ -115,8 +117,7 @@ func configureRedirect(w http.ResponseWriter, r *http.Request, rr *requests.Auth
 	} else {
 		rr.Redirect.URL = r.RequestURI
 	}
-
-	rr.Redirect.Enabled = true
+	
 	rr.Redirect.Separator = "?"
 
 	if strings.Contains(rr.Redirect.AuthURL, "?") {


### PR DESCRIPTION
Our e2e have found that the redirect unauthenticated stop working. Analysing the code we found at **handlers/redirect.go** that `rr.Redirect.Enabled` is initialised to false and never turn true if caddyfile contains `disable auth redirect query`

This bug has been introduced between release version 1.0.23 to 1.0.24.