### PR TITLE
Support for Discord OAuth2 provider

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -22,3 +22,5 @@
   email: paulaavvieira@hotmail.com
 - name: Sergiu Cozma
   email: sergiucozma1994@gmail.com
+- name: Riccardo Piola
+  email: riccardopiola@live.it

--- a/pkg/authn/icons/icon.go
+++ b/pkg/authn/icons/icon.go
@@ -69,6 +69,8 @@ func (icon *LoginIcon) Configure(s string) {
 			icon.ClassName = "lab la-github la-2x"
 		case "gitlab":
 			icon.ClassName = "lab la-gitlab la-2x"
+		case "discord":
+			icon.ClassName = "lab la-discord la-2x"
 		case "windows":
 			icon.ClassName = "lab la-windows la-2x"
 		case "azure":
@@ -122,6 +124,8 @@ func (icon *LoginIcon) Configure(s string) {
 			icon.BackgroundColor = "#fc6d26"
 		case "github":
 			icon.BackgroundColor = "#24292f"
+		case "discord":
+			icon.BackgroundColor = "#5865f2"
 		case "windows":
 			// MaterializeCSS "orange darken-1"
 			icon.BackgroundColor = "#fb8c00"
@@ -150,6 +154,8 @@ func (icon *LoginIcon) Configure(s string) {
 			icon.Text = "LinkedIn"
 		case "github":
 			icon.Text = "Github"
+		case "discord":
+			icon.Text = "Discord"
 		case "windows":
 			icon.Text = "Microsoft"
 		case "azure":
@@ -186,6 +192,8 @@ func (icon *LoginIcon) Configure(s string) {
 		case "windows":
 			// MaterializeCSS "orange darken-1"
 			icon.BackgroundColor = "#fb8c00"
+		case "discord":
+			icon.BackgroundColor = "#5865f2"
 		case "azure":
 			// MaterializeCSS "blue"
 			icon.BackgroundColor = "#03a9f4"

--- a/pkg/idp/oauth/authenticate.go
+++ b/pkg/idp/oauth/authenticate.go
@@ -125,7 +125,7 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 			var m map[string]interface{}
 
 			switch b.config.Driver {
-			case "github", "gitlab", "facebook":
+			case "github", "gitlab", "facebook", "discord":
 				m, err = b.fetchClaims(accessToken)
 				if err != nil {
 					return errors.ErrIdentityProviderOauthFetchClaimsFailed.WithArgs(err)

--- a/pkg/idp/oauth/config.go
+++ b/pkg/idp/oauth/config.go
@@ -158,6 +158,8 @@ func (cfg *Config) Validate() error {
 			cfg.Scopes = []string{"openid", "email", "profile"}
 		case "cognito":
 			cfg.Scopes = []string{"openid", "email", "profile"}
+		case "discord":
+			cfg.Scopes = []string{"identify"}
 		default:
 			cfg.Scopes = []string{"openid", "email", "profile"}
 		}
@@ -242,6 +244,11 @@ func (cfg *Config) Validate() error {
 	case "nextcloud":
 		cfg.AuthorizationURL = fmt.Sprintf("%s/apps/oauth2/authorize", cfg.BaseAuthURL)
 		cfg.TokenURL = fmt.Sprintf("%s/apps/oauth2/api/v1/token", cfg.BaseAuthURL)
+	case "discord":
+		cfg.BaseAuthURL = "https://discord.com/oauth2"
+		cfg.AuthorizationURL = "https://discord.com/oauth2/authorize"
+		cfg.TokenURL = "https://discord.com/api/oauth2/token"
+		cfg.RequiredTokenFields = []string{"access_token"}
 	case "generic":
 	case "":
 		return errors.ErrIdentityProviderConfig.WithArgs("driver name not found")
@@ -266,6 +273,7 @@ func (cfg *Config) Validate() error {
 	case "github":
 	case "facebook":
 	case "nextcloud":
+	case "discord":
 	default:
 		if len(cfg.JwksKeys) > 0 && cfg.AuthorizationURL != "" && cfg.TokenURL != "" {
 			for kid, fp := range cfg.JwksKeys {

--- a/pkg/idp/oauth/config_test.go
+++ b/pkg/idp/oauth/config_test.go
@@ -97,6 +97,39 @@ func TestValidateConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "validate discord oauth config",
+			config: &Config{
+				Name:         "discord",
+				Realm:        "discord",
+				Driver:       "discord",
+				ClientID:     "foo",
+				ClientSecret: "bar",
+			},
+			want: &Config{
+				Name:         "discord",
+				Realm:        "discord",
+				Driver:       "discord",
+				ClientID:     "foo",
+				ClientSecret: "bar",
+				// After the validation.
+				ServerName:          "discord.com",
+				IdentityTokenName:   "id_token", // maybe change this to access_token
+				Scopes:              []string{"identify"},
+				BaseAuthURL:         "https://discord.com/oauth2",
+				ResponseType:        []string{"code"},
+				RequiredTokenFields: []string{"access_token"},
+				AuthorizationURL:    "https://discord.com/oauth2/authorize",
+				TokenURL:            "https://discord.com/api/oauth2/token",
+				LoginIcon: &icons.LoginIcon{
+					ClassName:       "lab la-discord la-2x",
+					Color:           "white",
+					Text: 					 "Discord",
+					BackgroundColor: "#5865f2",
+					TextColor:       "#37474f",
+				},
+			},
+		},
+		{
 			name: "validate nextcloud oauth config",
 			config: &Config{
 				Name:         "nextcloud",

--- a/pkg/idp/oauth/provider.go
+++ b/pkg/idp/oauth/provider.go
@@ -207,6 +207,10 @@ func (b *IdentityProvider) Configure() error {
 		b.disableResponseType = true
 		b.disableNonce = true
 		b.enableAcceptHeader = true
+	case "discord":
+		b.disableKeyVerification = true
+		b.disableNonce = true
+		b.enableAcceptHeader = true
 	case "nextcloud":
 		b.disableKeyVerification = true
 	}

--- a/pkg/idp/oauth/user.go
+++ b/pkg/idp/oauth/user.go
@@ -412,11 +412,11 @@ func (b *IdentityProvider) fetchDiscordGuilds(authToken string) (*userData, erro
 	}
 
 	for _, guild := range guilds {
-		guild_id := guild["id"].(string)
+		guildID := guild["id"].(string)
 		// Exclude org from processing if it does not match org filters.
 		included := false
 		for _, rp := range b.userGroupFilters {
-			if rp.MatchString(guild_id) {
+			if rp.MatchString(guildID) {
 				included = true
 				break
 			}
@@ -432,11 +432,11 @@ func (b *IdentityProvider) fetchDiscordGuilds(authToken string) (*userData, erro
 				continue
 			}
 			if (perm & 0x08) == 0x08 { // Check for admin privileges
-				data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/admins", guild_id))
+				data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/admins", guildID))
 			}
 		}
 
-		data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/members", guild_id))
+		data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/members", guildID))
 	}
 
 	b.logger.Debug(


### PR DESCRIPTION
In this pull request I added support for the discord as a OAuth2 provider. 

Discord is a very convenient authentication provider for individuals wanting to add simple authentication to a server in order to give access to a group already assembled on a discord "server" (called "guilds" in discord dev terminology). 
Interest for this addition (aside from mine) has been shown in [this issue](https://github.com/greenpau/caddy-security/issues/143).

## Usage guide

### Registering a discord application

In order to use this plugin with caddy-security you'll need a to register an application in the [Discord Developer Portal](https://discord.com/developers/applications).

Once an application has been created, in the OAuth2 section, you'll find the `client_id` and `client_secret`. You'll also need to add `https://localhost/auth/oauth2/discord/authorization-code-callback` as a verified redirect url (Assuming the caddy server is running on localhost:443).

### Sample Caddyfile configuration

```caddyfile
oauth identity provider discord {
    realm discord
    driver discord
    client_id {$DISCORD_CLIENT_ID}
    client_secret {$DISCORD_CLIENT_SECRET}
    scopes identify email guilds # Optional, see notes below
    user_group_filters {$DISCORD_GUILD_ID} {$OTHER_GUILD_ID} # Optional, effective only if scope guilds is specified
}
```

By default the request for authentication to discord is made only with the "identify" scope (the bare minimum) that will give you back the id, username and avatar of the logged in user.

you can then match the user ID in the a `transform user` directive like this:

```caddyfile
transform user {
    match sub discord.com/{$SOME_DISCORD_ID}
    action add role authp/admin
}
```

The DISCORD_ID is a number uniquely identifying the user in question. You can get someone's discord id from the discord desktop app but first you need to enable Developer mode (Settings->App Settings->Advanced->Enable Developer Mode). Once that is done you can right click on someone's username and the last option in the popup will be "Copy ID".

If you add "email" to the list of scopes requested the email will also be saved.

### Filtering by guild

If "guilds" is added to the list of scopes requested an additional query will be made once the user is authenticated to fetch the guilds that the user is part of (discord api: `https://discord.com/api/v10/users/@me/guilds`). 

The obtained guild ids are then matched against the specified `user_group filters`, which is a list containing the guilds we are interested in (to get the ID of a guild use the same process as the for the user ID but instead you right click on a guild in the discord app with dev mode on).

If the filter check passes then additional `roles` will be added to the user as following:
1. If the user is a member of a guild => role `discord.com/{$DISCORD_GUILD_ID}/members`
2. If the user has admin privileges in a guild => role `discord.com/{$DISCORD_GUILD_ID}/admins`

You can them match them like this:

```caddyfile
transform user {
    match role discord.com/{$DISCORD_GUILD_ID}/admins
    action add role authp/admin
}

transform user {
    match role discord.com/{$DISCORD_GUILD_ID}/members
    action add role authp/user
}
```

## Notes and possible improvements

- Currently logging in while not being part of a guild in the filters **will not prevent the user from completing the login**. Instead the user will be assigned the default role of `authp/guest`. I belive this is the same behaviour as the other providers offering similiar filters (like Github orgs).

- If a user is an **admin of a guild he will receive both admin and member role**.

- Icon for discord in the authentication portal is not visible because it has white color on white background even though I changed the background color in `pkg/authn/icons/icon.go` to #5865f2 (official discord blue/purple).

- The `guilds` scope is required to check if the user is part of a guild. This requirement could be removed by making the check using a Bot authentication token (if there is a bot available in the guild), this should also enable discriminating particular discord roles.

## Disclaimer

This is the first time I use the GO language. I followed closely what the existing implementation was doing for other similar authentication methods (like github) so the work mostly consisted of adding a bunch extra cases on switch statements, still, the maintainer should check that there aren't any mistakes or misuses due to my inexperiance with the language.