### PR TITLE
config/keys: fail parsing if invalid source is set

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -8,6 +8,9 @@
 - name: Samuel Hitz
   email: hitz@anapaya.net
   company: Anapaya Systems AG
+- name: Lukas Vogel
+  email: vogel@anapaya.net
+  company: Anapaya Systems AG
 
 # By adding your name and email below, you I hereby consent to the Individual
 # CLA provided in assets/cla/individual_cla.md.

--- a/pkg/kms/key.go
+++ b/pkg/kms/key.go
@@ -154,6 +154,8 @@ func GetKeysFromConfig(cfg *CryptoKeyConfig) ([]*CryptoKey, error) {
 		default:
 			return nil, fmt.Errorf("unsupported env config type %s", cfg.EnvVarType)
 		}
+	default:
+		return nil, fmt.Errorf("unsupported source: '%s'", cfg.Source)
 	}
 
 	for _, k := range keys {


### PR DESCRIPTION
If an invalid source is specified in the key config, the parsing will error out.

Fixes #28