### PR TITLE
User info roles field name

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -11,6 +11,12 @@
 - name: Lukas Vogel
   email: vogel@anapaya.net
   company: Anapaya Systems AG
+- name: Thomas Ottenhus
+  email: ottenhus@uni-mainz.de
+  company: Johannes Gutenberg University Mainz
+- name: Moritz Schlarb
+  email: schlarbm@uni-mainz.de
+  company: Johannes Gutenberg University Mainz
 
 # By adding your name and email below, you I hereby consent to the Individual
 # CLA provided in assets/cla/individual_cla.md.

--- a/pkg/idp/config.go
+++ b/pkg/idp/config.go
@@ -98,6 +98,7 @@ func (cfg *IdentityProviderConfig) Validate() error {
 			"email_claim_check_disabled",
 			"login_icon",
 			"user_info_fields",
+			"user_info_roles_field_name",
 		}
 	case "saml":
 		requiredFields = []string{

--- a/pkg/idp/oauth/config.go
+++ b/pkg/idp/oauth/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	LoginIcon *icons.LoginIcon `json:"login_icon,omitempty" xml:"login_icon,omitempty" yaml:"login_icon,omitempty"`
 
 	UserInfoFields []string `json:"user_info_fields,omitempty" xml:"user_info_fields,omitempty" yaml:"user_info_fields,omitempty"`
+	UserInfoRolesFieldName string `json:"user_info_roles_field_name,omitempty" xml:"user_info_roles_field_name,omitempty" yaml:"user_info_roles_field_name,omitempty"`
 
 	// The name of the cookie storing id_token from OAuth provider.
 	IdentityTokenCookieName string `json:"identity_token_cookie_name,omitempty" xml:"identity_token_cookie_name,omitempty" yaml:"identity_token_cookie_name,omitempty"`

--- a/pkg/idp/oauth/provider.go
+++ b/pkg/idp/oauth/provider.go
@@ -68,6 +68,7 @@ type IdentityProvider struct {
 	requiredTokenFields    map[string]interface{}
 	scopeMap               map[string]interface{}
 	userInfoFields         map[string]interface{}
+	userInfoRolesFieldName string
 	// state stores cached state IDs
 	state         *stateManager
 	logger        *zap.Logger
@@ -225,6 +226,12 @@ func (b *IdentityProvider) Configure() error {
 	b.userInfoFields = make(map[string]interface{})
 	for _, fieldName := range b.config.UserInfoFields {
 		b.userInfoFields[fieldName] = true
+	}
+
+	if b.config.UserInfoRolesFieldName != "" {
+		b.userInfoRolesFieldName = b.config.UserInfoRolesFieldName
+	} else {
+		b.userInfoRolesFieldName = "roles"
 	}
 
 	// Configure user group filters, if any.

--- a/pkg/idp/oauth/user_info.go
+++ b/pkg/idp/oauth/user_info.go
@@ -85,7 +85,7 @@ func (b *IdentityProvider) fetchUserInfo(tokenData, userData map[string]interfac
 
 	var roles []string
 	if _, exists := b.userInfoFields["all"]; exists {
-		roles = extractUserInfoRoles(userinfo)
+		roles = extractUserInfoRoles(userinfo, b.userInfoRolesFieldName)
 		if len(userinfo) > 0 {
 			userData["userinfo"] = userinfo
 		}
@@ -96,7 +96,7 @@ func (b *IdentityProvider) fetchUserInfo(tokenData, userData map[string]interfac
 			}
 		}
 		if len(userinfo) > 0 {
-			roles = extractUserInfoRoles(userinfo)
+			roles = extractUserInfoRoles(userinfo, b.userInfoRolesFieldName)
 			if len(userinfo) > 0 {
 				userData["userinfo"] = userinfo
 			}
@@ -109,11 +109,11 @@ func (b *IdentityProvider) fetchUserInfo(tokenData, userData map[string]interfac
 	return nil
 }
 
-func extractUserInfoRoles(m map[string]interface{}) []string {
+func extractUserInfoRoles(m map[string]interface{}, rolesFieldName string) []string {
 	entries := make(map[string]interface{})
 	var roles []string
 	for k, v := range m {
-		if !strings.HasSuffix(k, "roles") && !strings.HasSuffix(k, "groups") {
+		if !strings.HasSuffix(k, rolesFieldName) && !strings.HasSuffix(k, "groups") {
 			continue
 		}
 		switch values := v.(type) {


### PR DESCRIPTION
This builds on and fixes the initial approach from https://github.com/glatzert/go-authcrunch/commit/8de8c6b3551f74243df07c1f6d083a88974cbb14 to add a new configuration directive to specify the name of the "roles" claim.

Requires https://github.com/greenpau/caddy-security/pull/218