### PR TITLE
Discord OAuth2 Provider - Extended to support Guild Roles

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -39,3 +39,6 @@
   email: riccardopiola@live.it
 - name: Nick Gregory
   email: ng-cla@openenterprise.co.uk
+- name: Michael Ellis
+  email: Michael94Ellis@gmail.com
+

--- a/pkg/idp/oauth/user.go
+++ b/pkg/idp/oauth/user.go
@@ -28,6 +28,10 @@ import (
 	"strings"
 )
 
+type discordMember struct {
+	Roles []string `json:"roles"`
+}
+
 type userData struct {
 	Groups []string `json:"groups,omitempty"`
 }
@@ -135,6 +139,7 @@ func (b *IdentityProvider) fetchClaims(tokenData map[string]interface{}) (map[st
 	switch b.config.Driver {
 	case "github", "gitlab", "discord":
 		req, err = http.NewRequest("GET", userURL, nil)
+
 		if err != nil {
 			return nil, err
 		}
@@ -425,53 +430,68 @@ func (b *IdentityProvider) fetchDiscordGuilds(authToken string) (*userData, erro
 			continue
 		}
 
+		b.logger.Debug(
+			"Checking Guild Permissions",
+			zap.String("guildName", guild["name"].(string)),
+		)
+
 		// Check if the user has special permissions
 		if _, exists := guild["permissions"]; exists {
-			perm, err := strconv.Atoi(guild["permissions"].(string))
+			// Parses to int64 for 32-bit system support
+			perm, err := strconv.ParseInt(guild["permissions"].(string), 10, 64)
 			if err != nil {
-				continue
-			}
-			if (perm & 0x08) == 0x08 { // Check for admin privileges
+				b.logger.Debug(
+					"Error converting Guild permissions to integer",
+					zap.Any("error", err),
+				)
+ 			} else if (perm & 0x08) == 0x08 { // Check for admin privileges
 				data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/admins", guildID))
+    			}
+		}
+
+		data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/members", guildID))
+		// Fetch roles information for the guild
+		if b.ScopeExists("guilds.members.read") {
+			reqURL = fmt.Sprintf("https://discord.com/api/v10/users/@me/guilds/%s/member", guildID)
+			req, err = http.NewRequest("GET", reqURL, nil)
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Accept", "application/json")
+			req.Header.Add("Authorization", "Bearer " + authToken)
+
+			resp, err = cli.Do(req)
+			if err != nil {
+				return nil, err
+			}
+
+			respBody, err = ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, err
+			}
+
+			var memberData discordMember
+			if err := json.Unmarshal(respBody, &memberData); err != nil {
+				b.logger.Debug(
+					"Guild Roles request failed",
+					zap.Any("response", respBody),
+					zap.Any("error", err),
+				)
+				return nil, err
+			}
+
+			for _, roleID := range memberData.Roles {
+				data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/role/%s", guildID, roleID))
 			}
 		}
 
-		data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/roles", guildID))
-		// Fetch roles for the guild
-		reqURL = fmt.Sprintf("https://discord.com/api/v10/guilds/%s/roles", guildID)
-		req, err = http.NewRequest("GET", reqURL, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Add("Authorization", "Bearer " + authToken)
-
-		resp, err = cli.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		respBody, err = ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-		return nil, err
-		}
-
-		roles := []map[string]interface{}{}
-		if err := json.Unmarshal(respBody, &roles); err != nil {
-			return nil, err
-		}
-
-		for _, role := range roles {
-			roleID := role["id"].(string)
-			data.Groups = append(data.Groups, fmt.Sprintf("discord.com/%s/roles/%s", guildID, roleID))
-		}
+		b.logger.Debug(
+			"Parsed additional discord user data",
+			zap.String("url", reqURL),
+			zap.Any("data", data),
+		)
 	}
-
-	b.logger.Debug(
-		"Parsed additional discord user data",
-		zap.String("url", reqURL),
-		zap.Any("data", data),
-	)
 
 	return data, nil
 }

--- a/pkg/idp/oauth/user.go
+++ b/pkg/idp/oauth/user.go
@@ -139,7 +139,6 @@ func (b *IdentityProvider) fetchClaims(tokenData map[string]interface{}) (map[st
 	switch b.config.Driver {
 	case "github", "gitlab", "discord":
 		req, err = http.NewRequest("GET", userURL, nil)
-
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Summary:
- This documentation is supporting the addition of Guild Role based authentication for Caddy-Security
- For each Discord Guild in user_group_filters an additional API call will be made to `https://discord.com/api/v10/users/@me/guilds/{guild.id}/member`. This API call will contain the Role IDs for a user in a given Guild
- Guild Roles can be used in the `transform user` block of the Caddyfile as described in the docs added. The new roles will be in this format `discord.com/{$DISCORD_GUILD_ID}/role/{$DISCORD_ROLE_ID}`
- Existing roles will continue to be added undisturbed (`dicord.com/{$GUILD_ID}/members`, `dicord.com/{$GUILD_ID}/admins`)
- Replaced a func that is fails on 32-bit systems related to assignment of the role `dicord.com/{$GUILD_ID}/admins`
- Minor typos fixes

Documentation PR - https://github.com/authp/authp.github.io/pull/53

Related: 
Caddy Community forum post- https://caddy.community/t/caddy-security-update-for-discord-guild-role-authentication/21609