### PR TITLE
feature: add autocomplete attribute to inputs

### DIFF
--- a/assets/cla/consent.yaml
+++ b/assets/cla/consent.yaml
@@ -45,4 +45,6 @@
   email: oss-cla@oettig.de
 - name: Phil Porada
   email: philporada@gmail.com
+- name: Simon Ledoux
+  email: simon@simon511000.fr
 

--- a/assets/portal/templates/basic/login.template
+++ b/assets/portal/templates/basic/login.template
@@ -40,7 +40,7 @@
                     <label for="username" class="block text-center pb-2 text-lg font-sans font-medium text-primary-700">Please provide username or email address</label>
                     <div class="app-inp-box">
                       <div class="app-inp-prf-img"><i class="las la-user"></i></div>
-                      <input class="app-inp-txt" id="username" name="username" type="text" autocorrect="off" autocapitalize="off" spellcheck="false" autofocus required />
+                      <input class="app-inp-txt" id="username" name="username" type="text" autocorrect="off" autocapitalize="off" autocomplete="username" spellcheck="false" autofocus required />
                     </div>
                   </div>
 

--- a/assets/portal/templates/basic/register.template
+++ b/assets/portal/templates/basic/register.template
@@ -79,7 +79,7 @@
                       class="app-gen-inp-txt validate"
                       pattern="{{ .Data.password_validate_pattern }}"
                       title="{{ .Data.password_validate_title }}"
-                      autocorrect="off" autocapitalize="off" autocomplete="current-password" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="new-password" spellcheck="false"
                       required
                     />
                   </div>
@@ -99,7 +99,7 @@
                   <div class="mt-1">
                     <input type="text" name="first_name" id="first_name"
                       class="app-gen-inp-txt"
-                      autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="given-name" spellcheck="false"
                     />
                   </div>
                 </div>
@@ -108,7 +108,7 @@
                   <div class="mt-1">
                     <input type="text" name="last_name" id="last_name"
                       class="app-gen-inp-txt"
-                      autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="family-name" spellcheck="false"
                     />
                   </div>
                 </div>

--- a/assets/portal/templates/basic/sandbox.template
+++ b/assets/portal/templates/basic/sandbox.template
@@ -83,7 +83,7 @@
                     </svg>
                   </div>
                   <input id="secret" name="secret" type="password" class="app-inp-txt"
-                         autocorrect="off" autocapitalize="off" spellcheck="false" autofocus required />
+                         autocorrect="off" autocapitalize="off" autocomplete="current-password" spellcheck="false" autofocus required />
                 </div>
               </div>
 
@@ -142,7 +142,7 @@
                 <div class="app-inp-box">
                   <input id="email" name="email" type="text"
                          class="app-inp-txt"
-                         autocorrect="off" autocapitalize="off" spellcheck="false" autocomplete="off"
+                         autocorrect="off" autocapitalize="off" autocomplete="email" spellcheck="false" autocomplete="off"
                          required />
                 </div>
               </div>

--- a/pkg/authn/ui/pages.go
+++ b/pkg/authn/ui/pages.go
@@ -58,7 +58,7 @@ var PageTemplates = map[string]string{
                     <label for="username" class="block text-center pb-2 text-lg font-sans font-medium text-primary-700">Please provide username or email address</label>
                     <div class="app-inp-box">
                       <div class="app-inp-prf-img"><i class="las la-user"></i></div>
-                      <input class="app-inp-txt" id="username" name="username" type="text" autocorrect="off" autocapitalize="off" spellcheck="false" autofocus required />
+                      <input class="app-inp-txt" id="username" name="username" type="text" autocorrect="off" autocapitalize="off" autocomplete="username" spellcheck="false" autofocus required />
                     </div>
                   </div>
 
@@ -391,7 +391,7 @@ var PageTemplates = map[string]string{
                       class="app-gen-inp-txt validate"
                       pattern="{{ .Data.password_validate_pattern }}"
                       title="{{ .Data.password_validate_title }}"
-                      autocorrect="off" autocapitalize="off" autocomplete="current-password" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="new-password" spellcheck="false"
                       required
                     />
                   </div>
@@ -411,7 +411,7 @@ var PageTemplates = map[string]string{
                   <div class="mt-1">
                     <input type="text" name="first_name" id="first_name"
                       class="app-gen-inp-txt"
-                      autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="given-name" spellcheck="false"
                     />
                   </div>
                 </div>
@@ -420,7 +420,7 @@ var PageTemplates = map[string]string{
                   <div class="mt-1">
                     <input type="text" name="last_name" id="last_name"
                       class="app-gen-inp-txt"
-                      autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false"
+                      autocorrect="off" autocapitalize="off" autocomplete="family-name" spellcheck="false"
                     />
                   </div>
                 </div>
@@ -1620,7 +1620,7 @@ function u2f_token_authenticate(formID, btnID) {
                     </svg>
                   </div>
                   <input id="secret" name="secret" type="password" class="app-inp-txt"
-                         autocorrect="off" autocapitalize="off" spellcheck="false" autofocus required />
+                         autocorrect="off" autocapitalize="off" autocomplete="current-password" spellcheck="false" autofocus required />
                 </div>
               </div>
 
@@ -1679,7 +1679,7 @@ function u2f_token_authenticate(formID, btnID) {
                 <div class="app-inp-box">
                   <input id="email" name="email" type="text"
                          class="app-inp-txt"
-                         autocorrect="off" autocapitalize="off" spellcheck="false" autocomplete="off"
+                         autocorrect="off" autocapitalize="off" autocomplete="email" spellcheck="false" autocomplete="off"
                          required />
                 </div>
               </div>


### PR DESCRIPTION
I have added the 'autocomplete' attribute to as many inputs as possible, in order to allow browsers and password managers to better understand the pages.
Specification: https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/autocomplete