### PR TITLE
explicitly set enitity id for saml service provider

### DIFF
--- a/pkg/idp/saml/provider.go
+++ b/pkg/idp/saml/provider.go
@@ -155,6 +155,10 @@ func (b *IdentityProvider) Configure() error {
 		entityID, _ := url.Parse(b.config.EntityID)
 		sp.MetadataURL = *entityID
 
+		if b.config.EntityID != "" {
+			sp.EntityID = b.config.EntityID
+		}
+
 		if b.idpMetadataURL != nil {
 			sp.MetadataURL = *b.idpMetadataURL
 		}


### PR DESCRIPTION
Right now keycloak's post request for saml cant be parsed, because entity id does not explicitly set.

Keycloak send "Client Id" as Audience. For example:
```
...
    <Conditions NotBefore="2025-06-05T07:41:20.111Z" NotOnOrAfter="2025-06-05T07:42:20.111Z">
      <AudienceRestriction>
        <Audience>urn:kyuubi-dev</Audience>
      </AudienceRestriction>
    </Conditions>
...
``` 

but service provider expects that it will be IDP metadata URL. So sp.ParseXMLResponse fail with error 
```
AudienceRestriction does not contain "https://my.keycloak.domain/realms/myorg/protocol/saml/descriptor"
```

but in Caddyfile "entity id" it is explicitly set up as "urn:kyuubi-dev".

This pull request explicitly set enitity id for saml service provider