### PR TITLE
discord fixes: include discriminator and allow overriding urls with query parameters

### DIFF
--- a/pkg/idp/oauth/authenticate_test.go
+++ b/pkg/idp/oauth/authenticate_test.go
@@ -1,0 +1,120 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/greenpau/go-authcrunch/internal/tests"
+	"github.com/greenpau/go-authcrunch/pkg/errors"
+	"github.com/greenpau/go-authcrunch/pkg/requests"
+	logutil "github.com/greenpau/go-authcrunch/pkg/util/log"
+	"go.uber.org/zap"
+)
+
+func must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func TestAuthenticate(t *testing.T) {
+	// For "state"
+	uuid.SetRand(rand.New(rand.NewSource(1)))
+	defer uuid.SetRand(nil)
+
+	testcases := []struct {
+		name      string
+		config    *Config
+		logger    *zap.Logger
+		shouldErr bool
+		errPhase  string
+		err       error
+		request   requests.Request
+		want      requests.Response
+	}{
+		{
+			name: "discord provider with overridden urls",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize?prompt=none",
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&prompt=none&" +
+					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=52fdfc07-2182-454f-963f-5f0f9a621d72",
+			},
+		},
+		{
+			name: "discord provider with overridden and invalid urls",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize?prompt=none" + string(byte(1)),
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					Request: must(http.NewRequest(http.MethodGet, "/foo?bar=baz", nil)),
+				},
+			},
+			shouldErr: true,
+			errPhase:  "authenticate",
+			err:       errors.ErrIdentityProviderConfig.WithArgs("could not parse authorization url"),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := []string{fmt.Sprintf("test name: %s", tc.name)}
+			msgs = append(msgs, fmt.Sprintf("config:\n%v", tc.config))
+
+			prv, err := NewIdentityProvider(tc.config, tc.logger)
+			if tests.EvalErrPhaseWithLog(t, err, "initialize", tc.errPhase, tc.shouldErr, tc.err, msgs) {
+				return
+			}
+
+			err = prv.Configure()
+			if tests.EvalErrPhaseWithLog(t, err, "configure", tc.errPhase, tc.shouldErr, tc.err, msgs) {
+				return
+			}
+
+			err = prv.Authenticate(&tc.request)
+			if tests.EvalErrPhaseWithLog(t, err, "authenticate", tc.errPhase, tc.shouldErr, tc.err, msgs) {
+				return
+			}
+
+			tests.EvalObjectsWithLog(t, "authenticate", tc.want, tc.request.Response, msgs)
+		})
+	}
+}

--- a/pkg/idp/oauth/config.go
+++ b/pkg/idp/oauth/config.go
@@ -16,11 +16,12 @@ package oauth
 
 import (
 	"fmt"
-	"github.com/greenpau/go-authcrunch/pkg/authn/icons"
-	"github.com/greenpau/go-authcrunch/pkg/errors"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/greenpau/go-authcrunch/pkg/authn/icons"
+	"github.com/greenpau/go-authcrunch/pkg/errors"
 )
 
 const defaultIdentityTokenCookieName string = "AUTHP_ID_TOKEN"
@@ -248,9 +249,15 @@ func (cfg *Config) Validate() error {
 		cfg.AuthorizationURL = fmt.Sprintf("%s/apps/oauth2/authorize", cfg.BaseAuthURL)
 		cfg.TokenURL = fmt.Sprintf("%s/apps/oauth2/api/v1/token", cfg.BaseAuthURL)
 	case "discord":
-		cfg.BaseAuthURL = "https://discord.com/oauth2"
-		cfg.AuthorizationURL = "https://discord.com/oauth2/authorize"
-		cfg.TokenURL = "https://discord.com/api/oauth2/token"
+		if cfg.BaseAuthURL == "" {
+			cfg.BaseAuthURL = "https://discord.com/oauth2"
+		}
+		if cfg.AuthorizationURL == "" {
+			cfg.AuthorizationURL = "https://discord.com/oauth2/authorize"
+		}
+		if cfg.TokenURL == "" {
+			cfg.TokenURL = "https://discord.com/api/oauth2/token"
+		}
 		cfg.RequiredTokenFields = []string{"access_token"}
 	case "linkedin":
 		if cfg.BaseAuthURL == "" {

--- a/pkg/idp/oauth/provider_test.go
+++ b/pkg/idp/oauth/provider_test.go
@@ -19,14 +19,15 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"github.com/greenpau/go-authcrunch/internal/tests"
-	"github.com/greenpau/go-authcrunch/pkg/errors"
-	logutil "github.com/greenpau/go-authcrunch/pkg/util/log"
-	"go.uber.org/zap"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/greenpau/go-authcrunch/internal/tests"
+	"github.com/greenpau/go-authcrunch/pkg/errors"
+	logutil "github.com/greenpau/go-authcrunch/pkg/util/log"
+	"go.uber.org/zap"
 )
 
 func TestNewIdentityProvider(t *testing.T) {
@@ -175,6 +176,86 @@ func TestNewIdentityProvider(t *testing.T) {
 						"class_name":       string("lab la-codepen la-2x"),
 						"color":            string("white"),
 						"text_color":       string("#37474f"),
+					},
+				},
+			},
+		},
+		{
+			name: "discord provider",
+			config: &Config{
+				Name:         "discord",
+				Realm:        "discord",
+				Driver:       "discord",
+				ClientID:     "foo",
+				ClientSecret: "bar",
+			},
+			logger: logutil.NewLogger(),
+			want: map[string]interface{}{
+				"kind":  "oauth",
+				"name":  "discord",
+				"realm": "discord",
+				"config": map[string]interface{}{
+					"name":                  "discord",
+					"realm":                 "discord",
+					"driver":                "discord",
+					"client_id":             "foo",
+					"client_secret":         "bar",
+					"server_name":           "discord.com",
+					"identity_token_name":   "id_token", // maybe change this to access_token
+					"scopes":                []any{"identify"},
+					"base_auth_url":         "https://discord.com/oauth2",
+					"response_type":         []any{"code"},
+					"required_token_fields": []any{"access_token"},
+					"authorization_url":     "https://discord.com/oauth2/authorize",
+					"token_url":             "https://discord.com/api/oauth2/token",
+					"login_icon": map[string]any{
+						"class_name":       "lab la-discord la-2x",
+						"color":            "white",
+						"text":             "Discord",
+						"background_color": "#5865f2",
+						"text_color":       "#37474f",
+					},
+				},
+			},
+		},
+		{
+			name: "discord provider with overridden urls",
+			config: &Config{
+				Name:         "discord",
+				Realm:        "discord",
+				Driver:       "discord",
+				ClientID:     "foo",
+				ClientSecret: "bar",
+
+				BaseAuthURL:      "https://discordapp.com/other",
+				AuthorizationURL: "https://discordapp.com/other/authorize?prompt=none",
+				TokenURL:         "https://discordapp.com/other/oauth2/token",
+			},
+			logger: logutil.NewLogger(),
+			want: map[string]interface{}{
+				"kind":  "oauth",
+				"name":  "discord",
+				"realm": "discord",
+				"config": map[string]interface{}{
+					"name":                  "discord",
+					"realm":                 "discord",
+					"driver":                "discord",
+					"client_id":             "foo",
+					"client_secret":         "bar",
+					"server_name":           "discordapp.com",
+					"identity_token_name":   "id_token", // maybe change this to access_token
+					"scopes":                []any{"identify"},
+					"base_auth_url":         "https://discordapp.com/other",
+					"response_type":         []any{"code"},
+					"required_token_fields": []any{"access_token"},
+					"authorization_url":     "https://discordapp.com/other/authorize?prompt=none",
+					"token_url":             "https://discordapp.com/other/oauth2/token",
+					"login_icon": map[string]any{
+						"class_name":       "lab la-discord la-2x",
+						"color":            "white",
+						"text":             "Discord",
+						"background_color": "#5865f2",
+						"text_color":       "#37474f",
 					},
 				},
 			},

--- a/pkg/idp/oauth/user.go
+++ b/pkg/idp/oauth/user.go
@@ -20,12 +20,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 type discordMember struct {
@@ -345,6 +346,9 @@ func (b *IdentityProvider) fetchClaims(tokenData map[string]interface{}) (map[st
 	case "discord":
 		m["sub"] = "discord.com/" + data["id"].(string)
 		m["name"] = data["username"]
+		if v, exists := data["discriminator"]; exists {
+			m["discriminator"] = v
+		}
 		m["picture"] = fmt.Sprintf("https://cdn.discordapp.com/avatars/%s/%s.png", data["id"], data["avatar"])
 		if _, exists := data["email"]; exists {
 			m["email"] = data["email"]


### PR DESCRIPTION
For un-migrated usernames, the discriminator is still significant in the name.

The URLs change allows setting something like `authorization_url https://discord.com/oauth2/authorize?prompt=none` to customize prompt behavior.

This also adds tests and picks up some changes from `go fmt`.