### PR TITLE
fix: sanitize URL path in request URL helpers to prevent reflected XSS

### DIFF
--- a/pkg/util/redirect_test.go
+++ b/pkg/util/redirect_test.go
@@ -16,8 +16,152 @@ package util
 
 import (
 	"github.com/greenpau/go-authcrunch/internal/tests"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 )
+
+func TestSanitizeURLPath(t *testing.T) {
+	var testcases = []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "clean path passes through unchanged",
+			input: "/auth/login",
+			want:  "/auth/login",
+		},
+		{
+			name:  "root path passes through unchanged",
+			input: "/",
+			want:  "/",
+		},
+		{
+			name:  "empty string passes through unchanged",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "script tag in path segment is encoded",
+			input: `/auth"><script>alert(1)</script>`,
+			want:  `/auth%22%3E%3Cscript%3Ealert%281%29%3C/script%3E`,
+		},
+		{
+			name:  "double quotes in path segment are encoded",
+			input: `/auth" onclick="alert(1)`,
+			want:  `/auth%22%20onclick=%22alert%281%29`,
+		},
+		{
+			name:  "single quotes in path segment are encoded",
+			input: "/auth'><img src=x onerror=alert(1)>",
+			want:  "/auth%27%3E%3Cimg%20src=x%20onerror=alert%281%29%3E",
+		},
+		{
+			name:  "path with hyphens and dots passes through",
+			input: "/auth/my-app/v2.0",
+			want:  "/auth/my-app/v2.0",
+		},
+		{
+			name:  "path with tilde and underscore passes through",
+			input: "/auth/my_app/~user",
+			want:  "/auth/my_app/~user",
+		},
+		{
+			// r.URL.Path is pre-decoded by net/http, so percent literals
+			// only appear if the raw request contained a literal %25.
+			// Double-encoding is expected and correct here.
+			name:  "percent in decoded path is re-encoded",
+			input: "/auth/%22foo",
+			want:  "/auth/%2522foo",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeURLPath(tc.input)
+			tests.EvalObjectsWithLog(t, "sanitized path", tc.want, got, []string{})
+		})
+	}
+}
+
+func TestGetBaseURLSanitizesPath(t *testing.T) {
+	var testcases = []struct {
+		name     string
+		path     string
+		match    string
+		wantPath string
+	}{
+		{
+			name:     "normal path returns clean base",
+			path:     "/auth/login",
+			match:    "/login",
+			wantPath: "/auth",
+		},
+		{
+			name:     "XSS payload in path is sanitized",
+			path:     `/auth"><script>alert(1)</script>/login`,
+			match:    "/login",
+			wantPath: `/auth%22%3E%3Cscript%3Ealert%281%29%3C/script%3E`,
+		},
+		{
+			name:     "event handler injection in path is sanitized",
+			path:     `/auth" onmouseover="alert(1)/login`,
+			match:    "/login",
+			wantPath: `/auth%22%20onmouseover=%22alert%281%29`,
+		},
+		{
+			name:     "no match returns full sanitized path",
+			path:     `/<img src=x>/nomatch`,
+			match:    "/willnotmatch",
+			wantPath: `/%3Cimg%20src=x%3E/nomatch`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{
+				URL:  &url.URL{Path: tc.path},
+				Host: "localhost",
+			}
+			_, basePath := GetBaseURL(r, tc.match)
+			tests.EvalObjectsWithLog(t, "base path", tc.wantPath, basePath, []string{})
+		})
+	}
+}
+
+func TestGetCurrentURLSanitizesPath(t *testing.T) {
+	var testcases = []struct {
+		name     string
+		path     string
+		wantSafe bool
+	}{
+		{
+			name:     "clean path passes through",
+			path:     "/auth/login",
+			wantSafe: true,
+		},
+		{
+			name:     "XSS payload in path is sanitized",
+			path:     `/auth"><script>alert(1)</script>/callback`,
+			wantSafe: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{
+				URL:  &url.URL{Path: tc.path},
+				Host: "localhost",
+			}
+			got := GetCurrentURL(r)
+			if tc.wantSafe && (strings.Contains(got, "<") || strings.Contains(got, ">") || strings.Contains(got, `"`)) {
+				t.Errorf("GetCurrentURL() returned unsanitized HTML chars: %s", got)
+			}
+		})
+	}
+}
 
 func TestStripQueryParam(t *testing.T) {
 


### PR DESCRIPTION
`GetBaseURL()`, `GetRelativeURL()`, and `GetCurrentURL()` pass `r.URL.Path` directly into template variables rendered via `text/template`, which performs no contextual escaping. A crafted URL path containing `<`, `>`, `"`, or `'` flows into href, src, and onclick attributes across all 9 page templates. Any route serving authcrunch pages is affected since the path comes from the raw request.

`GetCurrentURL()` is also reachable through `GetIssuerURL()` - the unsanitized path ends up in JWT claims as the `iss` field, which gets rendered as JSON on the whoami page via `{{ .Data.token }}`.

The fix adds `sanitizeURLPath()` which splits the path on `/` and re-encodes each segment with `url.PathEscape`. Clean paths pass through unchanged. Applied to all three functions that return `r.URL.Path` to callers. Switching to `html/template` would be the more comprehensive fix but touches all 460+ template references and needs its own testing pass - this targets the input side for now.

`GetCurrentBaseURL()` is not sanitized because it returns only `scheme://host` with no path component. The `repl` parameter in `GetRelativeURL()` is a caller-supplied static string, not user input.

15 new test cases covering XSS payloads (script tags, event handlers, img tags), safe path passthrough (hyphens, dots, tildes), and percent-encoding round-trip behavior.

Ref: greenpau/caddy-security#264