### PR TITLE
fix: validate Referer URL scheme in error page to prevent XSS

### DIFF
--- a/pkg/authn/respond_http.go
+++ b/pkg/authn/respond_http.go
@@ -119,10 +119,13 @@ func (p *Portal) handleHTTPError(ctx context.Context, w http.ResponseWriter, r *
 	resp.Data["authenticated"] = rr.Response.Authenticated
 
 	if rr.Response.RedirectURL != "" {
+		// RedirectURL is sourced from a server-set cookie, not raw user input.
 		resp.Data["go_back_url"] = rr.Response.RedirectURL
 	} else {
-		if r.Referer() != "" {
-			resp.Data["go_back_url"] = util.SanitizeURL(r.Referer())
+		ref := r.Referer()
+		parsed, err := url.Parse(ref)
+		if ref != "" && err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
+			resp.Data["go_back_url"] = util.SanitizeURL(ref)
 		} else {
 			resp.Data["go_back_url"] = "/"
 		}


### PR DESCRIPTION
`handleHTTPError()` in `pkg/authn/respond_http.go` passes `r.Referer()` through `SanitizeURL()` into the `go_back_url` template variable, which renders as `<a href="{{ .Data.go_back_url }}">` on error pages. `SanitizeURL()` escapes HTML metacharacters (`&<>"'`) but does not validate URL schemes. A crafted Referer header with `javascript:`, `data:`, or other executable schemes passes through intact and executes when the user clicks "Go back".

The fix parses the Referer inline in `handleHTTPError()` with `url.Parse` and allowlists `http` and `https` schemes. Non-matching schemes and malformed URLs fall back to `/` -- this is the key behavioral change. `SanitizeURL()` still handles character escaping; this validates the scheme.

The adjacent `RedirectURL` path on line 121 is not affected: it receives a formatted Set-Cookie header string from `GetCookie()`, not a raw URL, so `javascript:` schemes cannot survive the cookie formatting.

Builds on #70 (path sanitization, now merged). No conflicts.

10 new test cases: `javascript:` (lowercase and uppercase), `data:text/html,...`, `javascript:alert(1)//https://example.com` (scheme with path suffix mimicking a legitimate URL), `vbscript:`, `file:`, malformed `://no-scheme`, empty Referer, and valid `http`/`https` passthrough.

Ref: greenpau/caddy-security#267