### PR TITLE
fix: switch UI templates from text/template to html/template

### DIFF
--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -111,7 +111,7 @@ func TestRefererSanitization(t *testing.T) {
 		_ = p.handleHTTPError(context.Background(), rw, &r, request, 404)
 		rb := string(rw.body)
 
-		tests.EvalObjectsWithLog(t, "sanitized url", true, strings.Contains(rb, "https://www.google.com/search?hl=en%26q=testing%27%22()%26%%3Cacx%3E%3CScRiPt %3Ealert(9854)%3C/ScRiPt%3E"), []string{})
+		tests.EvalObjectsWithLog(t, "sanitized url", true, strings.Contains(rb, "https://www.google.com/search?hl=en%26q=testing%27%22%28%29%26%25%3Cacx%3E%3CScRiPt%20%3Ealert%289854%29%3C/ScRiPt%3E"), []string{})
 	})
 }
 

--- a/pkg/authn/ui/pages.go
+++ b/pkg/authn/ui/pages.go
@@ -1477,10 +1477,10 @@ var PageTemplates = map[string]string{
     </script>
     {{ end }}
     {{ if .Message }}
+    <div id="toast-msg" style="display:none"><span class="app-error-text">{{ .Message }}</span><button class="btn-flat toast-action" onclick="M.Toast.dismissAll();">Close</button></div>
     <script>
-    var toastHTML = '<span class="app-error-text">{{ .Message }}</span><button class="btn-flat toast-action" onclick="M.Toast.dismissAll();">Close</button>';
     toastElement = M.toast({
-      html: toastHTML,
+      html: document.getElementById('toast-msg').innerHTML,
       classes: 'toast-error'
     });
     const appContainer = document.querySelector('.app-container')
@@ -1490,15 +1490,7 @@ var PageTemplates = map[string]string{
     {{ if eq .Data.view "mfa-add-u2f" }}
     <script>
 function u2f_token_register(formID, btnID) {
-  const params = {
-    challenge: "{{ .Data.webauthn_challenge }}",
-    rp_name: "{{ .Data.webauthn_rp_name }}",
-    user_id: "{{ .Data.webauthn_user_id }}",
-    user_name: "{{ .Data.webauthn_user_email }}",
-    user_display_name: "{{ .Data.webauthn_user_display_name }}",
-    user_verification: "{{ .Data.webauthn_user_verification }}",
-    attestation: "{{ .Data.webauthn_attestation }}",
-  };
+  const params = {{ .Data.webauthn_params }};
   register_u2f_token(formID, btnID, params);
 }
     </script>
@@ -1507,28 +1499,7 @@ function u2f_token_register(formID, btnID) {
     {{ if eq .Data.view "mfa-test-u2f" }}
     <script>
 function u2f_token_authenticate(formID, btnID) {
-  const params = {
-    challenge: "{{ .Data.webauthn_challenge }}",
-    timeout: {{ .Data.webauthn_timeout }},
-    rp_name: "{{ .Data.webauthn_rp_name }}",
-    user_verification: "{{ .Data.webauthn_user_verification }}",
-    {{ if .Data.webauthn_credentials }}
-    allowed_credentials: [
-    {{ range .Data.webauthn_credentials }}
-      {
-        id: "{{ .id }}",
-        type: "{{ .type }}",
-        transports: [{{ .transports }}],
-      },
-    {{ end }}
-    ],
-    {{ else }}
-    allowed_credentials: [],
-    {{ end }}
-    ext_uvm: {{ .Data.webauthn_ext_uvm }},
-    ext_loc: {{ .Data.webauthn_ext_loc }},
-    ext_tx_auth_simple: "{{ .Data.webauthn_tx_auth_simple }}",
-  };
+  const params = {{ .Data.webauthn_params }};
   authenticate_u2f_token(formID, btnID, params);
 }
     </script>
@@ -2091,15 +2062,7 @@ function u2f_token_authenticate(formID, btnID) {
     {{ if eq .Data.view "mfa_u2f_register" }}
     <script>
     function u2f_token_register(formID, btnID) {
-      const params = {
-        challenge: "{{ .Data.webauthn_challenge }}",
-        rp_name: "{{ .Data.webauthn_rp_name }}",
-        user_id: "{{ .Data.webauthn_user_id }}",
-        user_name: "{{ .Data.webauthn_user_email }}",
-        user_display_name: "{{ .Data.webauthn_user_display_name }}",
-        user_verification: "{{ .Data.webauthn_user_verification }}",
-        attestation: "{{ .Data.webauthn_attestation }}",
-      };
+      const params = {{ .Data.webauthn_params }};
       register_u2f_token(formID, btnID, params);
     }
     </script>
@@ -2107,28 +2070,7 @@ function u2f_token_authenticate(formID, btnID) {
     {{ if eq .Data.view "mfa_u2f_auth" }}
     <script>
     function u2f_token_authenticate(formID) {
-      const params = {
-        challenge: "{{ .Data.webauthn_challenge }}",
-        timeout: {{ .Data.webauthn_timeout }},
-        rp_name: "{{ .Data.webauthn_rp_name }}",
-        user_verification: "{{ .Data.webauthn_user_verification }}",
-        {{- if .Data.webauthn_credentials }}
-        allowed_credentials: [
-        {{- range .Data.webauthn_credentials }}
-          {
-            id: "{{ .id }}",
-            type: "{{ .type }}",
-            transports: [{{ range .transports }}"{{ . }}",{{ end }}],
-          },
-        {{- end }}
-        ],
-        {{ else }}
-        allowed_credentials: [],
-        {{end -}}
-        ext_uvm: {{ .Data.webauthn_ext_uvm }},
-        ext_loc: {{ .Data.webauthn_ext_loc }},
-        ext_tx_auth_simple: "{{ .Data.webauthn_tx_auth_simple }}",
-      };
+      const params = {{ .Data.webauthn_params }};
       authenticate_u2f_token(formID, params);
     }
 
@@ -2136,10 +2078,10 @@ function u2f_token_authenticate(formID, btnID) {
     </script>
     {{ end }}
     {{ if .Message }}
+    <div id="toast-msg" style="display:none"><span>{{ .Message }}</span><button class="btn-flat toast-action" onclick="M.Toast.dismissAll();">Close</button></div>
     <script>
-    var toastHTML = '<span>{{ .Message }}</span><button class="btn-flat toast-action" onclick="M.Toast.dismissAll();">Close</button>';
     toastElement = M.toast({
-      html: toastHTML,
+      html: document.getElementById('toast-msg').innerHTML,
       classes: 'toast-error'
     });
     const appContainer = document.querySelector('.app-card-container')

--- a/pkg/authn/ui/ui.go
+++ b/pkg/authn/ui/ui.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"path"
 	"strings"
-	"text/template"
+	"html/template"
 
 	cfgutil "github.com/greenpau/go-authcrunch/pkg/util/cfg"
 )
@@ -280,18 +280,19 @@ func (f *Factory) DeleteTemplates() {
 func loadTemplateFromString(s, p string) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"pathjoin": path.Join,
-		"brsplitline": func(s string) string {
+		"brsplitline": func(s string) template.HTML {
+			escaped := template.HTMLEscapeString(s)
 			var output []rune
 			count := 0
-			for _, c := range s {
+			for _, c := range escaped {
 				count++
 				if count > 25 {
 					count = 0
-					output = append(output, []rune{'<', 'b', 'r', '>'}...)
+					output = append(output, '<', 'b', 'r', '>')
 				}
 				output = append(output, c)
 			}
-			return string(output)
+			return template.HTML(output)
 		},
 	}
 	t := template.New(s).Funcs(funcMap)


### PR DESCRIPTION
`text/template` does no escaping - user-controlled values in HTML/JS context pass through raw. `html/template` auto-escapes by rendering context.

The import swap is one line, but `html/template`'s JS escaper breaks the WebAuthn blocks - it applies JS-string escaping to values inside `<script>`, so the manually-quoted template vars end up with the wrong escaping. The fix consolidates ~40 individual template vars into `json.Marshal` → `template.JS`, which also fixes a pre-existing bug where credential transports rendered as Go slice syntax instead of a JS array.

Toast patterns moved from JS string interpolation to a hidden-div so `{{ .Message }}` renders in HTML context where auto-escaping is correct. `brsplitline` now escapes input before inserting `<br>` tags.

Form POST interface unchanged - `webauthn_challenge` hidden inputs still work. onclick handlers, portal handler, and email templates (`user_registry_notify.go`) are unaffected.