### PR TITLE
fix: switch UI templates from text/template to html/template

### DIFF
--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -111,7 +111,7 @@ func TestRefererSanitization(t *testing.T) {
 		_ = p.handleHTTPError(context.Background(), rw, &r, request, 404)
 		rb := string(rw.body)
 
-		tests.EvalObjectsWithLog(t, "sanitized url", true, strings.Contains(rb, "https://www.google.com/search?hl=en%26q=testing%27%22()%26%%3Cacx%3E%3CScRiPt %3Ealert(9854)%3C/ScRiPt%3E"), []string{})
+		tests.EvalObjectsWithLog(t, "sanitized url", true, strings.Contains(rb, "https://www.google.com/search?hl=en%26q=testing%27%22%28%29%26%25%3Cacx%3E%3CScRiPt%20%3Ealert%289854%29%3C/ScRiPt%3E"), []string{})
 	})
 }
 

--- a/pkg/authn/ui/ui.go
+++ b/pkg/authn/ui/ui.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"path"
 	"strings"
-	"text/template"
+	"html/template"
 
 	cfgutil "github.com/greenpau/go-authcrunch/pkg/util/cfg"
 )
@@ -282,18 +282,19 @@ func (f *Factory) DeleteTemplates() {
 func loadTemplateFromString(s, p string) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"pathjoin": path.Join,
-		"brsplitline": func(s string) string {
+		"brsplitline": func(s string) template.HTML {
+			escaped := template.HTMLEscapeString(s)
 			var output []rune
 			count := 0
-			for _, c := range s {
+			for _, c := range escaped {
 				count++
 				if count > 25 {
 					count = 0
-					output = append(output, []rune{'<', 'b', 'r', '>'}...)
+					output = append(output, '<', 'b', 'r', '>')
 				}
 				output = append(output, c)
 			}
-			return string(output)
+			return template.HTML(output)
 		},
 	}
 	t := template.New(s).Funcs(funcMap)


### PR DESCRIPTION
`loadTemplateFromString` in `pkg/authn/ui/ui.go` uses `text/template`, which does no output escaping. User-controlled values rendered through `{{ .Data.* }}` pass through raw into HTML responses. `html/template` is a drop-in replacement that auto-escapes by rendering context.

1. Import swap: `text/template` to `html/template`. All template types and FuncMap calls are in the `template` namespace already, nothing else changes.

2. `brsplitline`: escapes input with `HTMLEscapeString` before inserting `<br>` tags, returns `template.HTML` so the intentional tags aren't double-escaped.

One test assertion updated in `respond_http_test.go`: `html/template` applies URL-context normalization in `<a href>` attributes, so the expected percent-encoding in `TestRefererSanitization` is tighter. Same payload, stricter output.

Email templates (`pkg/messaging/`) are unaffected - they use their own `text/template` loader, not `loadTemplateFromString`. Full test suite green.