### PR TITLE
fix: log warning when user is locked out due to failed MFA attempts

### DIFF
--- a/pkg/authn/handle_http_sandbox.go
+++ b/pkg/authn/handle_http_sandbox.go
@@ -308,6 +308,14 @@ func (p *Portal) nextSandboxCheckpoint(r *http.Request, rr *requests.Request, us
 			}
 		case "mfa", "totp", "u2f":
 			if err := backend.Request(operator.CheckMfaLockout, rr); err != nil {
+				p.logger.Warn(
+					"user locked out due to too many failed MFA attempts",
+					zap.String("session_id", rr.Upstream.SessionID),
+					zap.String("request_id", rr.ID),
+					zap.String("src_ip", addrutil.GetSourceAddress(r)),
+					zap.String("src_conn_ip", addrutil.GetSourceConnAddress(r)),
+					zap.String("checkpoint_type", checkpoint.Type),
+				)
 				rr.Response.Code = http.StatusForbidden
 				m["title"] = "Authorization Failed"
 				m["view"] = "error"

--- a/pkg/authn/handle_json_login.go
+++ b/pkg/authn/handle_json_login.go
@@ -154,6 +154,14 @@ func (p *Portal) handleSandboxCheckpointVerification(_ context.Context, r *http.
 			prevCheckpointPassed = true
 		case checkpoint.Type == "totp" || (checkpoint.Type == "mfa" && challengeContainsOnlyNumbers):
 			if err := backend.Request(operator.CheckMfaLockout, rr); err != nil {
+				p.logger.Warn(
+					"user locked out due to too many failed MFA attempts",
+					zap.String("session_id", rr.Upstream.SessionID),
+					zap.String("request_id", rr.ID),
+					zap.String("src_ip", addrutil.GetSourceAddress(r)),
+					zap.String("src_conn_ip", addrutil.GetSourceConnAddress(r)),
+					zap.String("checkpoint_type", checkpoint.Type),
+				)
 				return fmt.Errorf("account temporarily locked due to too many failed MFA attempts")
 			}
 			rr.Flags.Enabled = true
@@ -287,6 +295,14 @@ func (p *Portal) handleSandboxCheckpointVerification(_ context.Context, r *http.
 			usr.Authenticator.NextChallenge = "mfa:u2f:" + base64.StdEncoding.EncodeToString(jsonChallenge)
 		case checkpoint.Type == "u2f":
 			if err := backend.Request(operator.CheckMfaLockout, rr); err != nil {
+				p.logger.Warn(
+					"user locked out due to too many failed MFA attempts",
+					zap.String("session_id", rr.Upstream.SessionID),
+					zap.String("request_id", rr.ID),
+					zap.String("src_ip", addrutil.GetSourceAddress(r)),
+					zap.String("src_conn_ip", addrutil.GetSourceConnAddress(r)),
+					zap.String("checkpoint_type", checkpoint.Type),
+				)
 				return fmt.Errorf("account temporarily locked due to too many failed MFA attempts")
 			}
 			rr.Flags.Enabled = true


### PR DESCRIPTION
The lockout check returned an error but didn't log it. Lockouts were invisible in caddy logs.

Adds p.logger.Warn at the three CheckMfaLockout call sites - TOTP and u2f paths in the JSON API handler, and the combined mfa/totp/u2f path in the HTTP sandbox handler.