### PR TITLE
feat: wire authentication challenge rules from static user config

### DIFF
--- a/pkg/ids/local/authenticator.go
+++ b/pkg/ids/local/authenticator.go
@@ -133,6 +133,25 @@ func (sa *Authenticator) Configure(fp string, users []*User) error {
 					}
 				}
 			}
+
+			if len(user.AuthChallengeRules) > 0 {
+				sa.logger.Debug(
+					"updating auth challenge rules for statically-defined identity store user",
+					zap.String("user", user.Username),
+					zap.String("email", user.EmailAddress),
+					zap.Int("auth_challenge_rule_count", len(user.AuthChallengeRules)),
+				)
+				req := &requests.Request{
+					User: requests.User{
+						Username:   user.Username,
+						Email:      user.EmailAddress,
+						Challenges: user.AuthChallengeRules,
+					},
+				}
+				if err := sa.db.OverwriteUserAuthChallengeRules(req); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/pkg/ids/local/authenticator_test.go
+++ b/pkg/ids/local/authenticator_test.go
@@ -125,6 +125,77 @@ func TestAuthenticate(t *testing.T) {
 	}
 }
 
+func TestConfigureWithAuthChallengeRules(t *testing.T) {
+	testcases := []struct {
+		name           string
+		users          []*User
+		wantChallenges []string
+		shouldErr      bool
+		err            error
+	}{
+		{
+			name: "user with auth challenge rules",
+			users: []*User{
+				{
+					Username:     "jsmith",
+					EmailAddress: "jsmith@localdomain.local",
+					Name:         "John Smith",
+					Password:     "My@Password123",
+					Roles:        []string{"authp/user"},
+					AuthChallengeRules: []string{
+						"u2f",
+						"password totp if u2f not available",
+						"password if u2f and totp not available",
+					},
+				},
+			},
+			wantChallenges: []string{"password"},
+		},
+		{
+			name: "user with invalid auth challenge rule",
+			users: []*User{
+				{
+					Username:           "baduser",
+					EmailAddress:       "baduser@localdomain.local",
+					Name:               "Bad User",
+					Password:           "My@Password123",
+					Roles:              []string{"authp/user"},
+					AuthChallengeRules: []string{"sms"},
+				},
+			},
+			shouldErr: true,
+			err:       errors.ErrUpdateUser.WithArgs(fmt.Errorf("unsupported challenge type: sms")),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := []string{fmt.Sprintf("test name: %s", tc.name)}
+			db, err := testutils.CreateEmptyTestDatabase("TestAuthChallengeRules")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+
+			b := NewAuthenticator()
+			b.logger = logutil.NewLogger()
+			err = b.Configure(db.GetPath(), tc.users)
+			if tests.EvalErrWithLog(t, err, "configure", tc.shouldErr, tc.err, msgs) {
+				return
+			}
+
+			req := &requests.Request{
+				User: requests.User{
+					Username: tc.users[0].Username,
+					Email:    tc.users[0].EmailAddress,
+				},
+			}
+			if err := b.IdentifyUser(req); err != nil {
+				t.Fatalf("identify user error: %v", err)
+			}
+			tests.EvalObjectsWithLog(t, "challenges", tc.wantChallenges, req.User.Challenges, msgs)
+		})
+	}
+}
+
 func TestNewAuthenticator(t *testing.T) {
 	testcases := []struct {
 		name         string

--- a/pkg/ids/local/user.go
+++ b/pkg/ids/local/user.go
@@ -30,4 +30,5 @@ type User struct {
 	Password                 string    `json:"password,omitempty" xml:"password,omitempty" yaml:"password,omitempty"`
 	PasswordOverwriteEnabled bool      `json:"password_overwrite_enabled,omitempty" xml:"password_overwrite_enabled,omitempty" yaml:"password_overwrite_enabled,omitempty"`
 	APIKeys                  []*APIKey `json:"api_keys,omitempty" xml:"api_keys,omitempty" yaml:"api_keys,omitempty"`
+	AuthChallengeRules       []string  `json:"auth_challenge_rules,omitempty" xml:"auth_challenge_rules,omitempty" yaml:"auth_challenge_rules,omitempty"`
 }


### PR DESCRIPTION
Wire auth_challenge_rules from static user configuration into the identity database during store initialization. When a user defined in the local identity store has auth challenge rules configured, they are applied via OverwriteUserAuthChallengeRules on startup - same pattern as API keys.

This is the identity store wiring for greenpau/caddy-security#470. The Caddyfile parser (caddy-security side) follows after release.