### PR TITLE
fix: preserve auto-generate path for default-only crypto config

### DIFF
--- a/pkg/kms/crypto_keystore.go
+++ b/pkg/kms/crypto_keystore.go
@@ -15,6 +15,7 @@
 package kms
 
 import (
+	"fmt"
 	"strings"
 
 	jwtlib "github.com/golang-jwt/jwt/v5"
@@ -50,7 +51,14 @@ func NewCryptoKeyStore(cfg *CryptoKeyStoreConfig, logger *zap.Logger) (*CryptoKe
 		logger: logger,
 	}
 	if len(cfg.RawKeyConfigs) > 0 {
-		cryptoKeyConfigs, err := ParseCryptoKeyConfigs(cfg.RawKeyConfigs)
+		keyConfigs := cfg.RawKeyConfigs
+		if cfg.TokenLifetime > 0 {
+			keyConfigs = append([]string{fmt.Sprintf("crypto default token lifetime %d", cfg.TokenLifetime)}, keyConfigs...)
+		}
+		if cfg.TokenName != "" {
+			keyConfigs = append([]string{fmt.Sprintf("crypto default token name %s", cfg.TokenName)}, keyConfigs...)
+		}
+		cryptoKeyConfigs, err := ParseCryptoKeyConfigs(keyConfigs)
 		if err != nil {
 			return nil, errors.ErrConfigDirectiveFail.WithArgs("crypto.key", cfg.RawKeyConfigs, err)
 		}

--- a/pkg/kms/crypto_keystore_config.go
+++ b/pkg/kms/crypto_keystore_config.go
@@ -61,14 +61,12 @@ func NewCryptoKeyStoreConfig(statements []string) (*CryptoKeyStoreConfig, error)
 				switch args[3] {
 				case "name":
 					cfg.TokenName = args[4]
-					cryptoKeyConfigs = append(cryptoKeyConfigs, statement)
 				case "lifetime":
 					lifetime, err := strconv.Atoi(args[4])
 					if err != nil {
 						return nil, errors.ErrCryptoKeyStoreConfigEntryInvalid.WithArgs(statement, err)
 					}
 					cfg.TokenLifetime = lifetime
-					cryptoKeyConfigs = append(cryptoKeyConfigs, statement)
 				default:
 					return nil, errors.ErrCryptoKeyStoreConfigEntryInvalid.WithArgs(statement, fmt.Sprintf("contains unsupported 'crypto default token' parameter: %s", args[3]))
 				}

--- a/pkg/kms/crypto_keystore_config_test.go
+++ b/pkg/kms/crypto_keystore_config_test.go
@@ -41,8 +41,6 @@ func TestNewCryptoKeyStoreConfig(t *testing.T) {
 				TokenName:     "AUTHP_ACCESS_TOKEN",
 				TokenLifetime: 3600,
 				RawKeyConfigs: []string{
-					"crypto default token lifetime 3600",
-					"crypto default token name AUTHP_ACCESS_TOKEN",
 					"crypto key sign-verify foobar",
 				},
 				AutoGenerateTag:  "default",

--- a/pkg/kms/crypto_keystore_test.go
+++ b/pkg/kms/crypto_keystore_test.go
@@ -350,6 +350,13 @@ func TestDefaultTokenLifetimePropagation(t *testing.T) {
 			},
 			wantLifetime: 900,
 		},
+		{
+			name: "only default lifetime without explicit key auto-generates",
+			config: []string{
+				"crypto default token lifetime 3600",
+			},
+			wantLifetime: 3600,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
PR #97 added default token config statements to `RawKeyConfigs` to forward lifetime and name to `ParseCryptoKeyConfigs`. This works when an explicit `crypto key` directive is present, but without one `RawKeyConfigs` is no longer empty and the auto-generate path doesn't fire.

Move the default forwarding from `NewCryptoKeyStoreConfig` (config parse) to `NewCryptoKeyStore` (keystore init). Defaults are prepended into a local copy before calling `ParseCryptoKeyConfigs`, keeping `cfg.RawKeyConfigs` clean for the auto-generate check.

Added test case for `crypto default token lifetime` without an explicit key.

Ref: greenpau/caddy-security#480