### PR TITLE
fix: strip leading dot from cookie domain config

### DIFF
--- a/pkg/authn/cookie/factory.go
+++ b/pkg/authn/cookie/factory.go
@@ -46,6 +46,15 @@ func NewFactory(c *Config) (*Factory, error) {
 		f.config = c
 	}
 	if f.config.Domains != nil {
+		// Strip leading dots from domain values (RFC 6265 Section 5.2.3).
+		for k, v := range f.config.Domains {
+			v.Domain = strings.TrimPrefix(v.Domain, ".")
+			if trimmedKey := strings.TrimPrefix(k, "."); trimmedKey != k {
+				delete(f.config.Domains, k)
+				f.config.Domains[trimmedKey] = v
+			}
+		}
+
 		domains := []string{}
 		domainList := []*DomainConfig{}
 		for _, v := range f.config.Domains {

--- a/pkg/authn/cookie/factory_test.go
+++ b/pkg/authn/cookie/factory_test.go
@@ -406,6 +406,42 @@ func TestFactory(t *testing.T) {
 				"session_grant":  "AUTHP_SESSION_ID=foobar; Domain=example.com; Path=/; Secure; HttpOnly;",
 			},
 		},
+		{
+			name: "leading dot domain config suffix match",
+			host: "admin.example.com",
+			config: &Config{
+				Domains: map[string]*DomainConfig{
+					".example.com": {
+						Seq:    0,
+						Domain: ".example.com",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"grant":          "AUTHP_ACCESS_TOKEN=foobar; Domain=example.com; Path=/; Secure; HttpOnly;",
+				"delete":         "AUTHP_ACCESS_TOKEN=delete; Domain=example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;",
+				"session_delete": "AUTHP_SESSION_ID=delete; Domain=example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;",
+				"session_grant":  "AUTHP_SESSION_ID=foobar; Domain=example.com; Path=/; Secure; HttpOnly;",
+			},
+		},
+		{
+			name: "leading dot domain config exact host match",
+			host: "example.com",
+			config: &Config{
+				Domains: map[string]*DomainConfig{
+					".example.com": {
+						Seq:    0,
+						Domain: ".example.com",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"grant":          "AUTHP_ACCESS_TOKEN=foobar; Domain=example.com; Path=/; Secure; HttpOnly;",
+				"delete":         "AUTHP_ACCESS_TOKEN=delete; Domain=example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;",
+				"session_delete": "AUTHP_SESSION_ID=delete; Domain=example.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT;",
+				"session_grant":  "AUTHP_SESSION_ID=foobar; Domain=example.com; Path=/; Secure; HttpOnly;",
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`cookie domain .example.com` (with leading dot) breaks cross-subdomain auth. The domain is stored as-is, and the suffix check in `evalHost` produces a double dot (`..example.com`) that never matches. Cookie falls back to host-only scope, causing redirect loops on subdomains.

Strip leading dots from domain keys and values in `NewFactory` so both forms behave identically.

Tests: two new cases covering subdomain match and exact host match with leading-dot config. Full suite passes.

Fixes greenpau/caddy-security#481