### PR TITLE
fix: collapse generic mfa when a specific MFA keyword is present

### DIFF
--- a/pkg/authn/handle_http_login.go
+++ b/pkg/authn/handle_http_login.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/greenpau/go-authcrunch/pkg/authchal"
 	"github.com/greenpau/go-authcrunch/pkg/authn/enums/operator"
 	"github.com/greenpau/go-authcrunch/pkg/idp"
 	"github.com/greenpau/go-authcrunch/pkg/ids"
@@ -175,6 +176,19 @@ func (p *Portal) injectUserChallenges(usr *user.User, data map[string]interface{
 		}
 	}
 
+	// Drop generic mfa if a specific MFA keyword is present, otherwise
+	// both dispatch as separate checkpoints.
+	if hasSpecificMFAChallenge(entries) {
+		dedup := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if e == authchal.MfaKeyword {
+				continue
+			}
+			dedup = append(dedup, e)
+		}
+		entries = dedup
+	}
+
 	checkpoints, err := user.NewCheckpoints(entries)
 	if err != nil {
 		return err
@@ -184,6 +198,18 @@ func (p *Portal) injectUserChallenges(usr *user.User, data map[string]interface{
 	}
 	usr.Checkpoints = checkpoints
 	return nil
+}
+
+// hasSpecificMFAChallenge reports whether the list contains a specific MFA
+// keyword that supersedes the generic mfa. Extend when adding new MFA keywords.
+func hasSpecificMFAChallenge(entries []string) bool {
+	for _, e := range entries {
+		switch e {
+		case authchal.TotpKeyword, authchal.U2fKeyword, authchal.EmailKeyword:
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Portal) identifyUserRequest(rr *requests.Request, identity map[string]string) error {

--- a/pkg/authn/handle_http_login_test.go
+++ b/pkg/authn/handle_http_login_test.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authn
+
+import (
+	"testing"
+
+	"github.com/greenpau/go-authcrunch/internal/tests"
+	"github.com/greenpau/go-authcrunch/pkg/authchal"
+	"github.com/greenpau/go-authcrunch/pkg/user"
+)
+
+func TestInjectUserChallenges(t *testing.T) {
+	var testcases = []struct {
+		name           string
+		userChallenges []string
+		dataChallenges interface{}
+		wantTypes      []string
+	}{
+		{
+			name:           "single-method totp with require mfa collapses generic",
+			userChallenges: []string{authchal.PasswordKeyword, authchal.TotpKeyword},
+			dataChallenges: []string{authchal.MfaKeyword},
+			wantTypes:      []string{authchal.PasswordKeyword, authchal.TotpKeyword},
+		},
+		{
+			name:           "single-method u2f with require mfa collapses generic",
+			userChallenges: []string{authchal.PasswordKeyword, authchal.U2fKeyword},
+			dataChallenges: []string{authchal.MfaKeyword},
+			wantTypes:      []string{authchal.PasswordKeyword, authchal.U2fKeyword},
+		},
+		{
+			name:           "multi-method user with require mfa unchanged",
+			userChallenges: []string{authchal.PasswordKeyword, authchal.MfaKeyword},
+			dataChallenges: []string{authchal.MfaKeyword},
+			wantTypes:      []string{authchal.PasswordKeyword, authchal.MfaKeyword},
+		},
+		{
+			name:           "zero-MFA user with require mfa keeps generic for enrollment",
+			userChallenges: []string{authchal.PasswordKeyword},
+			dataChallenges: []string{authchal.MfaKeyword},
+			wantTypes:      []string{authchal.PasswordKeyword, authchal.MfaKeyword},
+		},
+		{
+			name:           "single-method totp without require mfa unchanged",
+			userChallenges: []string{authchal.PasswordKeyword, authchal.TotpKeyword},
+			wantTypes:      []string{authchal.PasswordKeyword, authchal.TotpKeyword},
+		},
+		{
+			name:           "nil user challenges with require mfa",
+			userChallenges: nil,
+			dataChallenges: []string{authchal.MfaKeyword},
+			wantTypes:      []string{authchal.MfaKeyword},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Portal{}
+			usr := &user.User{}
+			data := map[string]interface{}{}
+			if tc.dataChallenges != nil {
+				data["challenges"] = tc.dataChallenges
+			}
+			err := p.injectUserChallenges(usr, data, tc.userChallenges)
+			tests.EvalObjectsWithLog(t, "error", nil, err, []string{})
+			gotTypes := []string{}
+			for _, cp := range usr.Checkpoints {
+				gotTypes = append(gotTypes, cp.Type)
+			}
+			tests.EvalObjectsWithLog(t, "checkpoint types", tc.wantTypes, gotTypes, []string{})
+		})
+	}
+}


### PR DESCRIPTION
greenpau/caddy-security#482 reporter hits the MFA prompt twice with `require mfa` set.

Identity store emits the specific keyword (`totp`/`u2f`/`email`) for single-method users. `require mfa` appends the generic `mfa`. The merge compares by exact string, so both survive and dispatch through the same MFA path.

Drops generic `mfa` from the merged list when a specific MFA keyword is present. Zero-MFA users keep `mfa` (no specific keyword to collapse against), so the enrollment path is unchanged.