### PR TITLE
Allow passing the "prompt" request parameter to Google Auth URLs.

### DIFF
--- a/pkg/idp/oauth/authenticate.go
+++ b/pkg/idp/oauth/authenticate.go
@@ -40,60 +40,26 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 	reqPath := r.Upstream.BaseURL + path.Join(r.Upstream.BasePath, r.Upstream.Method, r.Upstream.Realm)
 	r.Response.Code = http.StatusBadRequest
 
-	var accessTokenExists, idTokenExists, codeExists, stateExists, errorExists, loginHintExists, additionalScopesExists, promptExists bool
-	var reqParamsAccessToken, reqParamsIDToken, reqParamsState, reqParamsCode, reqParamsError, reqParamsLoginHint, reqParamsPrompt, additionalScopes string
-	reqParams := r.Upstream.Request.URL.Query()
-	if _, exists := reqParams["access_token"]; exists {
-		accessTokenExists = true
-		reqParamsAccessToken = reqParams["access_token"][0]
-	}
-	if _, exists := reqParams["id_token"]; exists {
-		idTokenExists = true
-		reqParamsIDToken = reqParams["id_token"][0]
-	}
-	if _, exists := reqParams["code"]; exists {
-		codeExists = true
-		reqParamsCode = reqParams["code"][0]
-	}
-	if _, exists := reqParams["state"]; exists {
-		stateExists = true
-		reqParamsState = reqParams["state"][0]
-	}
-	if _, exists := reqParams["error"]; exists {
-		errorExists = true
-		reqParamsError = reqParams["error"][0]
-	}
-	if _, exists := reqParams["login_hint"]; exists {
-		loginHintExists = true
-		reqParamsLoginHint = reqParams["login_hint"][0]
-	}
-	if _, exists := reqParams["prompt"]; exists {
-		promptExists = true
-		reqParamsPrompt = reqParams["prompt"][0]
-	}
-	if _, exists := reqParams["additional_scopes"]; exists {
-		additionalScopesExists = true
-		additionalScopes = reqParams["additional_scopes"][0]
-	}
+	reqParams := parseOAuthAuthenticateRequestParams(r.Upstream.Request.URL.Query())
 
-	if stateExists || errorExists || codeExists || accessTokenExists {
+	if reqParams.isOAuthResponse() {
 		b.logger.Debug(
 			"received OAuth 2.0 response",
 			zap.String("session_id", r.Upstream.SessionID),
 			zap.String("request_id", r.ID),
-			zap.Any("params", reqParams),
+			zap.Any("params", reqParams.values),
 		)
-		if errorExists {
-			if v, exists := reqParams["error_description"]; exists {
-				return errors.ErrIdentityProviderOauthAuthorizationFailedDetailed.WithArgs(reqParamsError, v[0])
+		if reqParams.errorExists {
+			if reqParams.errorDescriptionExists {
+				return errors.ErrIdentityProviderOauthAuthorizationFailedDetailed.WithArgs(reqParams.authError, reqParams.errorDescription)
 			}
-			return errors.ErrIdentityProviderOauthAuthorizationFailed.WithArgs(reqParamsError)
+			return errors.ErrIdentityProviderOauthAuthorizationFailed.WithArgs(reqParams.authError)
 		}
 		switch {
-		case codeExists && stateExists:
+		case reqParams.codeExists && reqParams.stateExists:
 			// Received Authorization Code
-			if b.state.exists(reqParamsState) {
-				b.state.addCode(reqParamsState, reqParamsCode)
+			if b.state.exists(reqParams.state) {
+				b.state.addCode(reqParams.state, reqParams.code)
 			} else {
 				return errors.ErrIdentityProviderOauthAuthorizationStateNotFound
 			}
@@ -101,22 +67,22 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 				"received OAuth 2.0 code and state from the authorization server",
 				zap.String("session_id", r.Upstream.SessionID),
 				zap.String("request_id", r.ID),
-				zap.String("state", reqParamsState),
-				zap.String("code", reqParamsCode),
+				zap.String("state", reqParams.state),
+				zap.String("code", reqParams.code),
 			)
 
 			reqRedirectURI := reqPath + "/authorization-code-callback"
 			var codeVerifier string
 			if !b.disablePKCE {
-				codeVerifier, _ = b.state.getVerifier(reqParamsState)
+				codeVerifier, _ = b.state.getVerifier(reqParams.state)
 			}
 			var accessToken map[string]interface{}
 			var err error
 			switch b.config.Driver {
 			case "facebook":
-				accessToken, err = b.fetchFacebookAccessToken(reqRedirectURI, reqParamsState, reqParamsCode)
+				accessToken, err = b.fetchFacebookAccessToken(reqRedirectURI, reqParams.state, reqParams.code)
 			default:
-				accessToken, err = b.fetchAccessToken(reqRedirectURI, reqParamsState, reqParamsCode, codeVerifier)
+				accessToken, err = b.fetchAccessToken(reqRedirectURI, reqParams.state, reqParams.code, codeVerifier)
 			}
 			if err != nil {
 				b.logger.Debug(
@@ -142,7 +108,7 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 					return errors.ErrIdentityProviderOauthFetchClaimsFailed.WithArgs(err)
 				}
 			default:
-				m, err = b.validateAccessToken(reqParamsState, accessToken)
+				m, err = b.validateAccessToken(reqParams.state, accessToken)
 				if err != nil {
 					return errors.ErrIdentityProviderOauthValidateAccessTokenFailed.WithArgs(err)
 				}
@@ -181,14 +147,14 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 				zap.String("request_id", r.ID),
 				zap.Any("claims", m),
 			)
-			b.state.del(reqParamsState)
+			b.state.del(reqParams.state)
 			return nil
-		case idTokenExists && accessTokenExists:
+		case reqParams.idTokenExists && reqParams.accessTokenExists:
 			accessToken := map[string]interface{}{
-				"access_token": reqParamsAccessToken,
-				"id_token":     reqParamsIDToken,
+				"access_token": reqParams.accessToken,
+				"id_token":     reqParams.idToken,
 			}
-			m, err := b.validateAccessToken(reqParamsState, accessToken)
+			m, err := b.validateAccessToken(reqParams.state, accessToken)
 			if err != nil {
 				return errors.ErrIdentityProviderOauthValidateAccessTokenFailed.WithArgs(err)
 			}
@@ -199,7 +165,7 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 			if b.config.IdentityTokenCookieEnabled {
 				r.Response.IdentityTokenCookie.Enabled = true
 				r.Response.IdentityTokenCookie.Name = b.config.IdentityTokenCookieName
-				r.Response.IdentityTokenCookie.Payload = reqParamsIDToken
+				r.Response.IdentityTokenCookie.Payload = reqParams.idToken
 			}
 
 			b.logger.Debug(
@@ -214,53 +180,13 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 	r.Response.Code = http.StatusFound
 	state := uuid.New().String()
 	nonce := util.GetRandomString(32)
-	authorizationURL, err := url.Parse(b.authorizationURL)
+	preparedRedirect, err := b.prepareAuthorizationRedirectURL(reqPath, reqParams, state, nonce, r.Upstream.SessionID, r.ID)
 	if err != nil {
-		return errors.ErrIdentityProviderConfig.WithArgs("could not parse authorization url")
+		return err
 	}
-	params := authorizationURL.Query()
-	// CSRF Protection
-	params.Set("state", state)
-	if !b.disableNonce {
-		// Server Side-Replay Protection
-		params.Set("nonce", nonce)
-	}
-	if !b.disableScope {
-		scopes := b.config.Scopes
-		if additionalScopesExists {
-			scopes = append(scopes, strings.Split(additionalScopes, " ")...)
-		}
-		params.Set("scope", strings.Join(scopes, " "))
-	}
-
-	if b.config.JsCallbackEnabled {
-		params.Set("redirect_uri", reqPath+"/authorization-code-js-callback")
-	} else {
-		params.Set("redirect_uri", reqPath+"/authorization-code-callback")
-	}
-
-	if !b.disableResponseType {
-		params.Set("response_type", strings.Join(b.config.ResponseType, " "))
-	}
-	if loginHintExists {
-		params.Set("login_hint", reqParamsLoginHint)
-	}
-	if promptExists {
-		if prompt, ok := normalizeOAuthPromptValue(reqParamsPrompt); ok {
-			params.Set("prompt", prompt)
-		} else {
-			b.logger.Warn(
-				"ignoring unsupported OAuth 2.0 prompt value",
-				zap.String("session_id", r.Upstream.SessionID),
-				zap.String("request_id", r.ID),
-				zap.String("prompt", strings.TrimSpace(reqParamsPrompt)),
-			)
-		}
-	}
-
-	params.Set("client_id", b.config.ClientID)
 
 	var codeVerifier string
+	var codeChallenge string
 	if !b.disablePKCE {
 		verifierBytes := make([]byte, 32)
 		if _, err := rand.Read(verifierBytes); err != nil {
@@ -268,13 +194,10 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 		}
 		codeVerifier = base64.RawURLEncoding.EncodeToString(verifierBytes)
 		h := sha256.Sum256([]byte(codeVerifier))
-		codeChallenge := base64.RawURLEncoding.EncodeToString(h[:])
-		params.Set("code_challenge", codeChallenge)
-		params.Set("code_challenge_method", "S256")
+		codeChallenge = base64.RawURLEncoding.EncodeToString(h[:])
 	}
 
-	authorizationURL.RawQuery = params.Encode()
-	r.Response.RedirectURL = authorizationURL.String()
+	r.Response.RedirectURL = b.finalizeAuthorizationRedirectURL(preparedRedirect, codeChallenge)
 
 	if err := b.state.add(state, nonce); err != nil {
 		return errors.ErrIdentityProviderOauthAuthorizationStateLimitReached
@@ -288,17 +211,6 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 		zap.String("redirect_url", r.Response.RedirectURL),
 	)
 	return nil
-}
-
-// See https://developers.google.com/identity/protocols/oauth2/web-server for supported prompt values.
-func normalizeOAuthPromptValue(prompt string) (string, bool) {
-	prompt = strings.TrimSpace(prompt)
-	switch prompt {
-	case "none", "consent", "select_account":
-		return prompt, true
-	default:
-		return "", false
-	}
 }
 
 func (b *IdentityProvider) fetchAccessToken(redirectURI, state, code, codeVerifier string) (map[string]interface{}, error) {

--- a/pkg/idp/oauth/authenticate.go
+++ b/pkg/idp/oauth/authenticate.go
@@ -246,7 +246,16 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 		params.Set("login_hint", reqParamsLoginHint)
 	}
 	if promptExists {
-		params.Set("prompt", reqParamsPrompt)
+		if prompt, ok := normalizeOAuthPromptValue(reqParamsPrompt); ok {
+			params.Set("prompt", prompt)
+		} else {
+			b.logger.Warn(
+				"ignoring unsupported OAuth 2.0 prompt value",
+				zap.String("session_id", r.Upstream.SessionID),
+				zap.String("request_id", r.ID),
+				zap.String("prompt", strings.TrimSpace(reqParamsPrompt)),
+			)
+		}
 	}
 
 	params.Set("client_id", b.config.ClientID)
@@ -279,6 +288,17 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 		zap.String("redirect_url", r.Response.RedirectURL),
 	)
 	return nil
+}
+
+// See https://developers.google.com/identity/protocols/oauth2/web-server for supported prompt values.
+func normalizeOAuthPromptValue(prompt string) (string, bool) {
+	prompt = strings.TrimSpace(prompt)
+	switch prompt {
+	case "none", "consent", "select_account":
+		return prompt, true
+	default:
+		return "", false
+	}
 }
 
 func (b *IdentityProvider) fetchAccessToken(redirectURI, state, code, codeVerifier string) (map[string]interface{}, error) {

--- a/pkg/idp/oauth/authenticate.go
+++ b/pkg/idp/oauth/authenticate.go
@@ -40,8 +40,8 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 	reqPath := r.Upstream.BaseURL + path.Join(r.Upstream.BasePath, r.Upstream.Method, r.Upstream.Realm)
 	r.Response.Code = http.StatusBadRequest
 
-	var accessTokenExists, idTokenExists, codeExists, stateExists, errorExists, loginHintExists, additionalScopesExists bool
-	var reqParamsAccessToken, reqParamsIDToken, reqParamsState, reqParamsCode, reqParamsError, reqParamsLoginHint, additionalScopes string
+	var accessTokenExists, idTokenExists, codeExists, stateExists, errorExists, loginHintExists, additionalScopesExists, promptExists bool
+	var reqParamsAccessToken, reqParamsIDToken, reqParamsState, reqParamsCode, reqParamsError, reqParamsLoginHint, reqParamsPrompt, additionalScopes string
 	reqParams := r.Upstream.Request.URL.Query()
 	if _, exists := reqParams["access_token"]; exists {
 		accessTokenExists = true
@@ -66,6 +66,10 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 	if _, exists := reqParams["login_hint"]; exists {
 		loginHintExists = true
 		reqParamsLoginHint = reqParams["login_hint"][0]
+	}
+	if _, exists := reqParams["prompt"]; exists {
+		promptExists = true
+		reqParamsPrompt = reqParams["prompt"][0]
 	}
 	if _, exists := reqParams["additional_scopes"]; exists {
 		additionalScopesExists = true
@@ -240,6 +244,9 @@ func (b *IdentityProvider) Authenticate(r *requests.Request) error {
 	}
 	if loginHintExists {
 		params.Set("login_hint", reqParamsLoginHint)
+	}
+	if promptExists {
+		params.Set("prompt", reqParamsPrompt)
 	}
 
 	params.Set("client_id", b.config.ClientID)

--- a/pkg/idp/oauth/authenticate_setup.go
+++ b/pkg/idp/oauth/authenticate_setup.go
@@ -1,0 +1,191 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/greenpau/go-authcrunch/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type oauthAuthenticateRequestParams struct {
+	values url.Values
+
+	accessToken            string
+	accessTokenExists      bool
+	idToken                string
+	idTokenExists          bool
+	code                   string
+	codeExists             bool
+	state                  string
+	stateExists            bool
+	authError              string
+	errorExists            bool
+	errorDescription       string
+	errorDescriptionExists bool
+	loginHint              string
+	loginHintExists        bool
+	additionalScopes       string
+	additionalScopesExists bool
+	prompt                 string
+	promptRaw              string
+	promptExists           bool
+	promptValid            bool
+}
+
+type preparedAuthorizationRedirectURL struct {
+	authorizationURL *url.URL
+	params           url.Values
+}
+
+func parseOAuthAuthenticateRequestParams(values url.Values) oauthAuthenticateRequestParams {
+	params := oauthAuthenticateRequestParams{
+		values: values,
+	}
+
+	if v, exists := getOAuthAuthenticateRequestParam(values, "access_token"); exists {
+		params.accessTokenExists = true
+		params.accessToken = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "id_token"); exists {
+		params.idTokenExists = true
+		params.idToken = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "code"); exists {
+		params.codeExists = true
+		params.code = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "state"); exists {
+		params.stateExists = true
+		params.state = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "error"); exists {
+		params.errorExists = true
+		params.authError = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "error_description"); exists {
+		params.errorDescriptionExists = true
+		params.errorDescription = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "login_hint"); exists {
+		params.loginHintExists = true
+		params.loginHint = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "additional_scopes"); exists {
+		params.additionalScopesExists = true
+		params.additionalScopes = v
+	}
+	if v, exists := getOAuthAuthenticateRequestParam(values, "prompt"); exists {
+		params.promptExists = true
+		params.promptRaw = v
+		if prompt, ok := normalizeOAuthPromptValue(v); ok {
+			params.prompt = prompt
+			params.promptValid = true
+		}
+	}
+
+	return params
+}
+
+func getOAuthAuthenticateRequestParam(values url.Values, key string) (string, bool) {
+	entries, exists := values[key]
+	if !exists {
+		return "", false
+	}
+	if len(entries) < 1 {
+		return "", true
+	}
+	return entries[0], true
+}
+
+func (p oauthAuthenticateRequestParams) isOAuthResponse() bool {
+	return p.stateExists || p.errorExists || p.codeExists || p.accessTokenExists
+}
+
+func (b *IdentityProvider) prepareAuthorizationRedirectURL(reqPath string, reqParams oauthAuthenticateRequestParams, state, nonce, sessionID, requestID string) (*preparedAuthorizationRedirectURL, error) {
+	authorizationURL, err := url.Parse(b.authorizationURL)
+	if err != nil {
+		return nil, errors.ErrIdentityProviderConfig.WithArgs("could not parse authorization url")
+	}
+
+	params := authorizationURL.Query()
+	params.Set("state", state)
+	if !b.disableNonce {
+		params.Set("nonce", nonce)
+	}
+	if !b.disableScope {
+		scopes := b.config.Scopes
+		if reqParams.additionalScopesExists {
+			scopes = append(scopes, strings.Split(reqParams.additionalScopes, " ")...)
+		}
+		params.Set("scope", strings.Join(scopes, " "))
+	}
+
+	if b.config.JsCallbackEnabled {
+		params.Set("redirect_uri", reqPath+"/authorization-code-js-callback")
+	} else {
+		params.Set("redirect_uri", reqPath+"/authorization-code-callback")
+	}
+
+	if !b.disableResponseType {
+		params.Set("response_type", strings.Join(b.config.ResponseType, " "))
+	}
+	if reqParams.loginHintExists {
+		params.Set("login_hint", reqParams.loginHint)
+	}
+
+	if reqParams.promptExists {
+		if reqParams.promptValid {
+			params.Set("prompt", reqParams.prompt)
+		} else {
+			b.logger.Warn(
+				"ignoring unsupported OAuth 2.0 prompt value",
+				zap.String("session_id", sessionID),
+				zap.String("request_id", requestID),
+				zap.String("prompt", strings.TrimSpace(reqParams.promptRaw)),
+			)
+		}
+	}
+
+	params.Set("client_id", b.config.ClientID)
+
+	return &preparedAuthorizationRedirectURL{
+		authorizationURL: authorizationURL,
+		params:           params,
+	}, nil
+}
+
+func (b *IdentityProvider) finalizeAuthorizationRedirectURL(prepared *preparedAuthorizationRedirectURL, codeChallenge string) string {
+	if !b.disablePKCE && codeChallenge != "" {
+		prepared.params.Set("code_challenge", codeChallenge)
+		prepared.params.Set("code_challenge_method", "S256")
+	}
+
+	prepared.authorizationURL.RawQuery = prepared.params.Encode()
+	return prepared.authorizationURL.String()
+}
+
+// See https://developers.google.com/identity/protocols/oauth2/web-server for supported prompt values.
+func normalizeOAuthPromptValue(prompt string) (string, bool) {
+	prompt = strings.TrimSpace(prompt)
+	switch prompt {
+	case "none", "consent", "select_account":
+		return prompt, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/idp/oauth/authenticate_setup.go
+++ b/pkg/idp/oauth/authenticate_setup.go
@@ -148,7 +148,7 @@ func (b *IdentityProvider) prepareAuthorizationRedirectURL(reqPath string, reqPa
 		params.Set("login_hint", reqParams.loginHint)
 	}
 
-	if reqParams.promptExists {
+	if b.config.Driver == "google" && reqParams.promptExists {
 		if reqParams.promptValid {
 			params.Set("prompt", reqParams.prompt)
 		} else {

--- a/pkg/idp/oauth/authenticate_setup.go
+++ b/pkg/idp/oauth/authenticate_setup.go
@@ -16,6 +16,7 @@ package oauth
 
 import (
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/greenpau/go-authcrunch/pkg/errors"
@@ -173,13 +174,19 @@ func (b *IdentityProvider) finalizeAuthorizationRedirectURL(prepared *preparedAu
 	return prepared.authorizationURL.String()
 }
 
+var validOAuthPromptValues = []string{
+	"none",
+	"consent",
+	"select_account",
+	"consent select_account",
+	"select_account consent",
+}
+
 // See https://developers.google.com/identity/protocols/oauth2/web-server for supported prompt values.
 func normalizeOAuthPromptValue(prompt string) (string, bool) {
-	prompt = strings.TrimSpace(prompt)
-	switch prompt {
-	case "none", "consent", "select_account":
+	prompt = strings.Join(strings.Fields(prompt), " ")
+	if slices.Contains(validOAuthPromptValues, prompt) {
 		return prompt, true
-	default:
-		return "", false
 	}
+	return "", false
 }

--- a/pkg/idp/oauth/authenticate_setup.go
+++ b/pkg/idp/oauth/authenticate_setup.go
@@ -41,10 +41,8 @@ type oauthAuthenticateRequestParams struct {
 	loginHintExists        bool
 	additionalScopes       string
 	additionalScopesExists bool
-	prompt                 string
 	promptRaw              string
 	promptExists           bool
-	promptValid            bool
 }
 
 type preparedAuthorizationRedirectURL struct {
@@ -92,10 +90,6 @@ func parseOAuthAuthenticateRequestParams(values url.Values) oauthAuthenticateReq
 	if v, exists := getOAuthAuthenticateRequestParam(values, "prompt"); exists {
 		params.promptExists = true
 		params.promptRaw = v
-		if prompt, ok := normalizeOAuthPromptValue(v); ok {
-			params.prompt = prompt
-			params.promptValid = true
-		}
 	}
 
 	return params
@@ -149,8 +143,8 @@ func (b *IdentityProvider) prepareAuthorizationRedirectURL(reqPath string, reqPa
 	}
 
 	if b.config.Driver == "google" && reqParams.promptExists {
-		if reqParams.promptValid {
-			params.Set("prompt", reqParams.prompt)
+		if prompt, ok := normalizeOAuthPromptValue(reqParams.promptRaw); ok {
+			params.Set("prompt", prompt)
 		} else {
 			b.logger.Warn(
 				"ignoring unsupported OAuth 2.0 prompt value",

--- a/pkg/idp/oauth/authenticate_setup_test.go
+++ b/pkg/idp/oauth/authenticate_setup_test.go
@@ -73,7 +73,7 @@ func mustParseRedirectQuery(t *testing.T, redirectURL string) url.Values {
 	return parsedURL.Query()
 }
 
-func TestParseOAuthAuthenticateRequestParamsEmptyQueryIsNotOAuthResponse(t *testing.T) {
+func TestEmptyQueryIsNotOAuthResponse(t *testing.T) {
 	params := parseOAuthAuthenticateRequestParams(url.Values{})
 
 	if params.isOAuthResponse() {
@@ -81,7 +81,7 @@ func TestParseOAuthAuthenticateRequestParamsEmptyQueryIsNotOAuthResponse(t *test
 	}
 }
 
-func TestGetOAuthAuthenticateRequestParamHandlesExistingKeyWithNoValues(t *testing.T) {
+func TestRequestParamExistsWithoutValue(t *testing.T) {
 	values := url.Values{
 		"prompt": []string{},
 	}
@@ -96,7 +96,7 @@ func TestGetOAuthAuthenticateRequestParamHandlesExistingKeyWithNoValues(t *testi
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesCodeAndState(t *testing.T) {
+func TestCodeAndStateAreParsed(t *testing.T) {
 	values := url.Values{}
 	values.Set("code", "code-1")
 	values.Set("state", "state-1")
@@ -114,7 +114,7 @@ func TestParseOAuthAuthenticateRequestParamsParsesCodeAndState(t *testing.T) {
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesErrorDescription(t *testing.T) {
+func TestAuthorizationErrorIsParsed(t *testing.T) {
 	values := url.Values{}
 	values.Set("error", "access_denied")
 	values.Set("error_description", "denied by provider")
@@ -129,7 +129,7 @@ func TestParseOAuthAuthenticateRequestParamsParsesErrorDescription(t *testing.T)
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesAccessAndIDTokens(t *testing.T) {
+func TestTokensAreParsed(t *testing.T) {
 	values := url.Values{}
 	values.Set("access_token", "access-token-1")
 	values.Set("id_token", "id-token-1")
@@ -144,7 +144,7 @@ func TestParseOAuthAuthenticateRequestParamsParsesAccessAndIDTokens(t *testing.T
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesLoginHintAndAdditionalScopes(t *testing.T) {
+func TestLoginHintAndScopesAreParsed(t *testing.T) {
 	values := url.Values{}
 	values.Set("login_hint", "user@example.com")
 	values.Set("additional_scopes", "email profile")
@@ -159,70 +159,100 @@ func TestParseOAuthAuthenticateRequestParamsParsesLoginHintAndAdditionalScopes(t
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesPromptNone(t *testing.T) {
-	values := url.Values{}
-	values.Set("prompt", "none")
+func TestValidGooglePrompts(t *testing.T) {
+	testcases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "trims prompt",
+			raw:  "  consent  ",
+			want: "consent",
+		},
+		{
+			name: "allows consent and select_account",
+			raw:  "consent select_account",
+			want: "consent select_account",
+		},
+		{
+			name: "preserves request order",
+			raw:  "select_account consent",
+			want: "select_account consent",
+		},
+		{
+			name: "collapses whitespace",
+			raw:  "consent\t select_account\n",
+			want: "consent select_account",
+		},
+		{
+			name: "allows none by itself",
+			raw:  "none",
+			want: "none",
+		},
+	}
 
-	params := parseOAuthAuthenticateRequestParams(values)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt, ok := normalizeOAuthPromptValue(tc.raw)
 
-	if !params.promptExists || params.promptRaw != "none" {
-		t.Fatalf("expected prompt %q, got %q", "none", params.promptRaw)
+			if !ok || prompt != tc.want {
+				t.Fatalf("expected valid prompt %q, got %q", tc.want, prompt)
+			}
+		})
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesPromptConsent(t *testing.T) {
-	values := url.Values{}
-	values.Set("prompt", "consent")
+func TestInvalidGooglePrompts(t *testing.T) {
+	testcases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "empty prompt",
+			raw:  "",
+		},
+		{
+			name: "unknown prompt",
+			raw:  "bogus",
+		},
+		{
+			name: "unknown prompt mixed with valid prompt",
+			raw:  "consent bogus",
+		},
+		{
+			name: "none mixed with consent",
+			raw:  "none consent",
+		},
+		{
+			name: "none mixed with select_account",
+			raw:  "select_account none",
+		},
+		{
+			name: "duplicate consent",
+			raw:  "consent consent",
+		},
+		{
+			name: "duplicate select_account",
+			raw:  "select_account select_account",
+		},
+	}
 
-	params := parseOAuthAuthenticateRequestParams(values)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			prompt, ok := normalizeOAuthPromptValue(tc.raw)
 
-	if !params.promptExists || params.promptRaw != "consent" {
-		t.Fatalf("expected prompt %q, got %q", "consent", params.promptRaw)
+			if ok {
+				t.Fatalf("expected prompt %q to be invalid", tc.raw)
+			}
+			if prompt != "" {
+				t.Fatalf("expected normalized prompt to be empty, got %q", prompt)
+			}
+		})
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsParsesPromptSelectAccount(t *testing.T) {
-	values := url.Values{}
-	values.Set("prompt", "select_account")
-
-	params := parseOAuthAuthenticateRequestParams(values)
-
-	if !params.promptExists || params.promptRaw != "select_account" {
-		t.Fatalf("expected prompt %q, got %q", "select_account", params.promptRaw)
-	}
-}
-
-func TestNormalizeOAuthPromptValueTrimsPrompt(t *testing.T) {
-	values := url.Values{}
-	values.Set("prompt", "  consent  ")
-
-	params := parseOAuthAuthenticateRequestParams(values)
-	prompt, ok := normalizeOAuthPromptValue(params.promptRaw)
-
-	if !ok || prompt != "consent" {
-		t.Fatalf("expected valid prompt %q, got %q", "consent", prompt)
-	}
-}
-
-func TestNormalizeOAuthPromptValueRejectsInvalidPrompt(t *testing.T) {
-	values := url.Values{}
-	values.Set("prompt", "bogus")
-
-	params := parseOAuthAuthenticateRequestParams(values)
-	prompt, ok := normalizeOAuthPromptValue(params.promptRaw)
-
-	if !params.promptExists {
-		t.Fatal("expected prompt to exist")
-	}
-	if ok {
-		t.Fatal("expected prompt to be invalid")
-	}
-	if prompt != "" {
-		t.Fatalf("expected normalized prompt to be empty, got %q", prompt)
-	}
-}
-
-func TestPrepareAuthorizationRedirectURLPreservesConfiguredQueryParams(t *testing.T) {
+func TestConfiguredQueryParamsArePreserved(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?access_type=offline&prompt=none"
 
@@ -237,7 +267,7 @@ func TestPrepareAuthorizationRedirectURLPreservesConfiguredQueryParams(t *testin
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t *testing.T) {
+func TestGooglePromptOverridesConfiguredPrompt(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
 	values := url.Values{}
@@ -251,7 +281,21 @@ func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLIgnoresRequestPromptForNonGoogleDriver(t *testing.T) {
+func TestGoogleMultiPromptOverridesConfiguredPrompt(t *testing.T) {
+	provider := newGoogleAuthorizationSetupTestProvider()
+	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
+	values := url.Values{}
+	values.Set("prompt", "consent select_account")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("prompt") != "consent select_account" {
+		t.Fatalf("expected prompt %q, got %q", "consent select_account", query.Get("prompt"))
+	}
+}
+
+func TestNonGooglePromptIsIgnored(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.config.Driver = "discord"
 	values := url.Values{}
@@ -265,7 +309,7 @@ func TestPrepareAuthorizationRedirectURLIgnoresRequestPromptForNonGoogleDriver(t
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLOmitsInvalidRequestPrompt(t *testing.T) {
+func TestInvalidGooglePromptIsOmitted(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "bogus")
 
@@ -277,7 +321,7 @@ func TestPrepareAuthorizationRedirectURLOmitsInvalidRequestPrompt(t *testing.T) 
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLInvalidRequestPromptDoesNotOverrideConfiguredPrompt(t *testing.T) {
+func TestInvalidGooglePromptKeepsConfiguredPrompt(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
 	values := url.Values{}
@@ -291,7 +335,7 @@ func TestPrepareAuthorizationRedirectURLInvalidRequestPromptDoesNotOverrideConfi
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLForwardsLoginHint(t *testing.T) {
+func TestLoginHintIsForwarded(t *testing.T) {
 	values := url.Values{}
 	values.Set("login_hint", "user@example.com")
 
@@ -303,7 +347,7 @@ func TestPrepareAuthorizationRedirectURLForwardsLoginHint(t *testing.T) {
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLAppendsAdditionalScopes(t *testing.T) {
+func TestAdditionalScopesAreAppended(t *testing.T) {
 	values := url.Values{}
 	values.Set("additional_scopes", "email profile")
 
@@ -315,7 +359,7 @@ func TestPrepareAuthorizationRedirectURLAppendsAdditionalScopes(t *testing.T) {
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLUsesAuthorizationCodeCallback(t *testing.T) {
+func TestAuthorizationCodeCallbackIsUsed(t *testing.T) {
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
 	query := mustParseRedirectQuery(t, redirect)
 
@@ -325,7 +369,7 @@ func TestPrepareAuthorizationRedirectURLUsesAuthorizationCodeCallback(t *testing
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLUsesJSCallbackWhenEnabled(t *testing.T) {
+func TestJSCallbackIsUsed(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.config.JsCallbackEnabled = true
 
@@ -338,7 +382,7 @@ func TestPrepareAuthorizationRedirectURLUsesJSCallbackWhenEnabled(t *testing.T) 
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLOmitsScopeWhenDisabled(t *testing.T) {
+func TestScopeCanBeDisabled(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableScope = true
 
@@ -350,7 +394,7 @@ func TestPrepareAuthorizationRedirectURLOmitsScopeWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLOmitsResponseTypeWhenDisabled(t *testing.T) {
+func TestResponseTypeCanBeDisabled(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableResponseType = true
 
@@ -362,7 +406,7 @@ func TestPrepareAuthorizationRedirectURLOmitsResponseTypeWhenDisabled(t *testing
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLOmitsNonceWhenDisabled(t *testing.T) {
+func TestNonceCanBeDisabled(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableNonce = true
 
@@ -374,7 +418,7 @@ func TestPrepareAuthorizationRedirectURLOmitsNonceWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestFinalizeAuthorizationRedirectURLAddsPKCEChallenge(t *testing.T) {
+func TestPKCEChallengeIsAdded(t *testing.T) {
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
 	query := mustParseRedirectQuery(t, redirect)
 
@@ -386,7 +430,7 @@ func TestFinalizeAuthorizationRedirectURLAddsPKCEChallenge(t *testing.T) {
 	}
 }
 
-func TestFinalizeAuthorizationRedirectURLOmitsPKCEWhenDisabled(t *testing.T) {
+func TestPKCECanBeDisabled(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disablePKCE = true
 
@@ -401,7 +445,7 @@ func TestFinalizeAuthorizationRedirectURLOmitsPKCEWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestPrepareAuthorizationRedirectURLReturnsConfigErrorBeforePKCESetup(t *testing.T) {
+func TestInvalidAuthorizationURLFailsBeforePKCE(t *testing.T) {
 	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none" + string(byte(1))
 

--- a/pkg/idp/oauth/authenticate_setup_test.go
+++ b/pkg/idp/oauth/authenticate_setup_test.go
@@ -1,0 +1,407 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"net/url"
+	"testing"
+
+	autherrors "github.com/greenpau/go-authcrunch/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	authorizationSetupTestReqPath = "https://hostname/route"
+	authorizationSetupTestState   = "state-1"
+	authorizationSetupTestNonce   = "nonce-1"
+	authorizationSetupTestPKCE    = "challenge-1"
+	authorizationSetupTestSession = "session-1"
+	authorizationSetupTestRequest = "request-1"
+)
+
+func newAuthorizationSetupTestProvider() *IdentityProvider {
+	return &IdentityProvider{
+		config: &Config{
+			ClientID:     "foo",
+			Scopes:       []string{"identify"},
+			ResponseType: []string{"code"},
+		},
+		authorizationURL: "https://domain/oauth/authorize",
+		logger:           zap.NewNop(),
+	}
+}
+
+func mustPrepareAndFinalizeAuthorizationRedirect(t *testing.T, provider *IdentityProvider, params oauthAuthenticateRequestParams) string {
+	t.Helper()
+
+	preparedRedirect, err := provider.prepareAuthorizationRedirectURL(
+		authorizationSetupTestReqPath,
+		params,
+		authorizationSetupTestState,
+		authorizationSetupTestNonce,
+		authorizationSetupTestSession,
+		authorizationSetupTestRequest,
+	)
+	if err != nil {
+		t.Fatalf("prepareAuthorizationRedirectURL() error = %v", err)
+	}
+
+	return provider.finalizeAuthorizationRedirectURL(preparedRedirect, authorizationSetupTestPKCE)
+}
+
+func mustParseRedirectQuery(t *testing.T, redirectURL string) url.Values {
+	t.Helper()
+
+	parsedURL, err := url.Parse(redirectURL)
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	return parsedURL.Query()
+}
+
+func TestParseOAuthAuthenticateRequestParamsEmptyQueryIsNotOAuthResponse(t *testing.T) {
+	params := parseOAuthAuthenticateRequestParams(url.Values{})
+
+	if params.isOAuthResponse() {
+		t.Fatal("expected empty query to not be an OAuth response")
+	}
+}
+
+func TestGetOAuthAuthenticateRequestParamHandlesExistingKeyWithNoValues(t *testing.T) {
+	values := url.Values{
+		"prompt": []string{},
+	}
+
+	value, exists := getOAuthAuthenticateRequestParam(values, "prompt")
+
+	if !exists {
+		t.Fatal("expected prompt key to exist")
+	}
+	if value != "" {
+		t.Fatalf("expected empty prompt value, got %q", value)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsParsesCodeAndState(t *testing.T) {
+	values := url.Values{}
+	values.Set("code", "code-1")
+	values.Set("state", "state-1")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.codeExists || params.code != "code-1" {
+		t.Fatalf("expected code %q, got %q", "code-1", params.code)
+	}
+	if !params.stateExists || params.state != "state-1" {
+		t.Fatalf("expected state %q, got %q", "state-1", params.state)
+	}
+	if !params.isOAuthResponse() {
+		t.Fatal("expected code and state to be an OAuth response")
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsParsesErrorDescription(t *testing.T) {
+	values := url.Values{}
+	values.Set("error", "access_denied")
+	values.Set("error_description", "denied by provider")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.errorExists || params.authError != "access_denied" {
+		t.Fatalf("expected error %q, got %q", "access_denied", params.authError)
+	}
+	if !params.errorDescriptionExists || params.errorDescription != "denied by provider" {
+		t.Fatalf("expected error_description %q, got %q", "denied by provider", params.errorDescription)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsParsesAccessAndIDTokens(t *testing.T) {
+	values := url.Values{}
+	values.Set("access_token", "access-token-1")
+	values.Set("id_token", "id-token-1")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.accessTokenExists || params.accessToken != "access-token-1" {
+		t.Fatalf("expected access_token %q, got %q", "access-token-1", params.accessToken)
+	}
+	if !params.idTokenExists || params.idToken != "id-token-1" {
+		t.Fatalf("expected id_token %q, got %q", "id-token-1", params.idToken)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsParsesLoginHintAndAdditionalScopes(t *testing.T) {
+	values := url.Values{}
+	values.Set("login_hint", "user@example.com")
+	values.Set("additional_scopes", "email profile")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.loginHintExists || params.loginHint != "user@example.com" {
+		t.Fatalf("expected login_hint %q, got %q", "user@example.com", params.loginHint)
+	}
+	if !params.additionalScopesExists || params.additionalScopes != "email profile" {
+		t.Fatalf("expected additional_scopes %q, got %q", "email profile", params.additionalScopes)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsAllowsPromptNone(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "none")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.promptExists || !params.promptValid || params.prompt != "none" {
+		t.Fatalf("expected valid prompt %q, got %q", "none", params.prompt)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsAllowsPromptConsent(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "consent")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.promptExists || !params.promptValid || params.prompt != "consent" {
+		t.Fatalf("expected valid prompt %q, got %q", "consent", params.prompt)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsAllowsPromptSelectAccount(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "select_account")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.promptExists || !params.promptValid || params.prompt != "select_account" {
+		t.Fatalf("expected valid prompt %q, got %q", "select_account", params.prompt)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsTrimsPrompt(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "  consent  ")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.promptExists || !params.promptValid || params.prompt != "consent" {
+		t.Fatalf("expected valid prompt %q, got %q", "consent", params.prompt)
+	}
+}
+
+func TestParseOAuthAuthenticateRequestParamsRejectsInvalidPrompt(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "bogus")
+
+	params := parseOAuthAuthenticateRequestParams(values)
+
+	if !params.promptExists {
+		t.Fatal("expected prompt to exist")
+	}
+	if params.promptValid {
+		t.Fatal("expected prompt to be invalid")
+	}
+	if params.prompt != "" {
+		t.Fatalf("expected normalized prompt to be empty, got %q", params.prompt)
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLPreservesConfiguredQueryParams(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.authorizationURL = "https://domain/oauth/authorize?access_type=offline&prompt=none"
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("access_type") != "offline" {
+		t.Fatalf("expected access_type %q, got %q", "offline", query.Get("access_type"))
+	}
+	if query.Get("prompt") != "none" {
+		t.Fatalf("expected prompt %q, got %q", "none", query.Get("prompt"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
+	values := url.Values{}
+	values.Set("prompt", "consent")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("prompt") != "consent" {
+		t.Fatalf("expected prompt %q, got %q", "consent", query.Get("prompt"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLOmitsInvalidRequestPrompt(t *testing.T) {
+	values := url.Values{}
+	values.Set("prompt", "bogus")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["prompt"]; exists {
+		t.Fatalf("expected prompt to be omitted, got %q", query.Get("prompt"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLInvalidRequestPromptDoesNotOverrideConfiguredPrompt(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
+	values := url.Values{}
+	values.Set("prompt", "bogus")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("prompt") != "none" {
+		t.Fatalf("expected configured prompt %q, got %q", "none", query.Get("prompt"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLForwardsLoginHint(t *testing.T) {
+	values := url.Values{}
+	values.Set("login_hint", "user@example.com")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("login_hint") != "user@example.com" {
+		t.Fatalf("expected login_hint %q, got %q", "user@example.com", query.Get("login_hint"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLAppendsAdditionalScopes(t *testing.T) {
+	values := url.Values{}
+	values.Set("additional_scopes", "email profile")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("scope") != "identify email profile" {
+		t.Fatalf("expected scope %q, got %q", "identify email profile", query.Get("scope"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLUsesAuthorizationCodeCallback(t *testing.T) {
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	expected := authorizationSetupTestReqPath + "/authorization-code-callback"
+	if query.Get("redirect_uri") != expected {
+		t.Fatalf("expected redirect_uri %q, got %q", expected, query.Get("redirect_uri"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLUsesJSCallbackWhenEnabled(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.config.JsCallbackEnabled = true
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	expected := authorizationSetupTestReqPath + "/authorization-code-js-callback"
+	if query.Get("redirect_uri") != expected {
+		t.Fatalf("expected redirect_uri %q, got %q", expected, query.Get("redirect_uri"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLOmitsScopeWhenDisabled(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.disableScope = true
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["scope"]; exists {
+		t.Fatalf("expected scope to be omitted, got %q", query.Get("scope"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLOmitsResponseTypeWhenDisabled(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.disableResponseType = true
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["response_type"]; exists {
+		t.Fatalf("expected response_type to be omitted, got %q", query.Get("response_type"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLOmitsNonceWhenDisabled(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.disableNonce = true
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["nonce"]; exists {
+		t.Fatalf("expected nonce to be omitted, got %q", query.Get("nonce"))
+	}
+}
+
+func TestFinalizeAuthorizationRedirectURLAddsPKCEChallenge(t *testing.T) {
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if query.Get("code_challenge") != authorizationSetupTestPKCE {
+		t.Fatalf("expected code_challenge %q, got %q", authorizationSetupTestPKCE, query.Get("code_challenge"))
+	}
+	if query.Get("code_challenge_method") != "S256" {
+		t.Fatalf("expected code_challenge_method %q, got %q", "S256", query.Get("code_challenge_method"))
+	}
+}
+
+func TestFinalizeAuthorizationRedirectURLOmitsPKCEWhenDisabled(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.disablePKCE = true
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["code_challenge"]; exists {
+		t.Fatalf("expected code_challenge to be omitted, got %q", query.Get("code_challenge"))
+	}
+	if _, exists := query["code_challenge_method"]; exists {
+		t.Fatalf("expected code_challenge_method to be omitted, got %q", query.Get("code_challenge_method"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLReturnsConfigErrorBeforePKCESetup(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none" + string(byte(1))
+
+	_, err := provider.prepareAuthorizationRedirectURL(
+		authorizationSetupTestReqPath,
+		parseOAuthAuthenticateRequestParams(url.Values{}),
+		authorizationSetupTestState,
+		authorizationSetupTestNonce,
+		authorizationSetupTestSession,
+		authorizationSetupTestRequest,
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expected := autherrors.ErrIdentityProviderConfig.WithArgs("could not parse authorization url")
+	if err.Error() != expected.Error() {
+		t.Fatalf("expected error %q, got %q", expected, err)
+	}
+}

--- a/pkg/idp/oauth/authenticate_setup_test.go
+++ b/pkg/idp/oauth/authenticate_setup_test.go
@@ -159,64 +159,66 @@ func TestParseOAuthAuthenticateRequestParamsParsesLoginHintAndAdditionalScopes(t
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsAllowsPromptNone(t *testing.T) {
+func TestParseOAuthAuthenticateRequestParamsParsesPromptNone(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "none")
 
 	params := parseOAuthAuthenticateRequestParams(values)
 
-	if !params.promptExists || !params.promptValid || params.prompt != "none" {
-		t.Fatalf("expected valid prompt %q, got %q", "none", params.prompt)
+	if !params.promptExists || params.promptRaw != "none" {
+		t.Fatalf("expected prompt %q, got %q", "none", params.promptRaw)
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsAllowsPromptConsent(t *testing.T) {
+func TestParseOAuthAuthenticateRequestParamsParsesPromptConsent(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "consent")
 
 	params := parseOAuthAuthenticateRequestParams(values)
 
-	if !params.promptExists || !params.promptValid || params.prompt != "consent" {
-		t.Fatalf("expected valid prompt %q, got %q", "consent", params.prompt)
+	if !params.promptExists || params.promptRaw != "consent" {
+		t.Fatalf("expected prompt %q, got %q", "consent", params.promptRaw)
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsAllowsPromptSelectAccount(t *testing.T) {
+func TestParseOAuthAuthenticateRequestParamsParsesPromptSelectAccount(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "select_account")
 
 	params := parseOAuthAuthenticateRequestParams(values)
 
-	if !params.promptExists || !params.promptValid || params.prompt != "select_account" {
-		t.Fatalf("expected valid prompt %q, got %q", "select_account", params.prompt)
+	if !params.promptExists || params.promptRaw != "select_account" {
+		t.Fatalf("expected prompt %q, got %q", "select_account", params.promptRaw)
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsTrimsPrompt(t *testing.T) {
+func TestNormalizeOAuthPromptValueTrimsPrompt(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "  consent  ")
 
 	params := parseOAuthAuthenticateRequestParams(values)
+	prompt, ok := normalizeOAuthPromptValue(params.promptRaw)
 
-	if !params.promptExists || !params.promptValid || params.prompt != "consent" {
-		t.Fatalf("expected valid prompt %q, got %q", "consent", params.prompt)
+	if !ok || prompt != "consent" {
+		t.Fatalf("expected valid prompt %q, got %q", "consent", prompt)
 	}
 }
 
-func TestParseOAuthAuthenticateRequestParamsRejectsInvalidPrompt(t *testing.T) {
+func TestNormalizeOAuthPromptValueRejectsInvalidPrompt(t *testing.T) {
 	values := url.Values{}
 	values.Set("prompt", "bogus")
 
 	params := parseOAuthAuthenticateRequestParams(values)
+	prompt, ok := normalizeOAuthPromptValue(params.promptRaw)
 
 	if !params.promptExists {
 		t.Fatal("expected prompt to exist")
 	}
-	if params.promptValid {
+	if ok {
 		t.Fatal("expected prompt to be invalid")
 	}
-	if params.prompt != "" {
-		t.Fatalf("expected normalized prompt to be empty, got %q", params.prompt)
+	if prompt != "" {
+		t.Fatalf("expected normalized prompt to be empty, got %q", prompt)
 	}
 }
 

--- a/pkg/idp/oauth/authenticate_setup_test.go
+++ b/pkg/idp/oauth/authenticate_setup_test.go
@@ -35,6 +35,7 @@ func newAuthorizationSetupTestProvider() *IdentityProvider {
 	return &IdentityProvider{
 		config: &Config{
 			ClientID:     "foo",
+			Driver:       "google",
 			Scopes:       []string{"identify"},
 			ResponseType: []string{"code"},
 		},
@@ -245,6 +246,20 @@ func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t
 
 	if query.Get("prompt") != "consent" {
 		t.Fatalf("expected prompt %q, got %q", "consent", query.Get("prompt"))
+	}
+}
+
+func TestPrepareAuthorizationRedirectURLIgnoresRequestPromptForNonGoogleDriver(t *testing.T) {
+	provider := newAuthorizationSetupTestProvider()
+	provider.config.Driver = "discord"
+	values := url.Values{}
+	values.Set("prompt", "consent")
+
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(values))
+	query := mustParseRedirectQuery(t, redirect)
+
+	if _, exists := query["prompt"]; exists {
+		t.Fatalf("expected prompt to be omitted, got %q", query.Get("prompt"))
 	}
 }
 

--- a/pkg/idp/oauth/authenticate_setup_test.go
+++ b/pkg/idp/oauth/authenticate_setup_test.go
@@ -31,7 +31,7 @@ const (
 	authorizationSetupTestRequest = "request-1"
 )
 
-func newAuthorizationSetupTestProvider() *IdentityProvider {
+func newGoogleAuthorizationSetupTestProvider() *IdentityProvider {
 	return &IdentityProvider{
 		config: &Config{
 			ClientID:     "foo",
@@ -223,7 +223,7 @@ func TestNormalizeOAuthPromptValueRejectsInvalidPrompt(t *testing.T) {
 }
 
 func TestPrepareAuthorizationRedirectURLPreservesConfiguredQueryParams(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?access_type=offline&prompt=none"
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -238,7 +238,7 @@ func TestPrepareAuthorizationRedirectURLPreservesConfiguredQueryParams(t *testin
 }
 
 func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
 	values := url.Values{}
 	values.Set("prompt", "consent")
@@ -252,7 +252,7 @@ func TestPrepareAuthorizationRedirectURLRequestPromptOverridesConfiguredPrompt(t
 }
 
 func TestPrepareAuthorizationRedirectURLIgnoresRequestPromptForNonGoogleDriver(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.config.Driver = "discord"
 	values := url.Values{}
 	values.Set("prompt", "consent")
@@ -269,7 +269,7 @@ func TestPrepareAuthorizationRedirectURLOmitsInvalidRequestPrompt(t *testing.T) 
 	values := url.Values{}
 	values.Set("prompt", "bogus")
 
-	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
 	query := mustParseRedirectQuery(t, redirect)
 
 	if _, exists := query["prompt"]; exists {
@@ -278,7 +278,7 @@ func TestPrepareAuthorizationRedirectURLOmitsInvalidRequestPrompt(t *testing.T) 
 }
 
 func TestPrepareAuthorizationRedirectURLInvalidRequestPromptDoesNotOverrideConfiguredPrompt(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none"
 	values := url.Values{}
 	values.Set("prompt", "bogus")
@@ -295,7 +295,7 @@ func TestPrepareAuthorizationRedirectURLForwardsLoginHint(t *testing.T) {
 	values := url.Values{}
 	values.Set("login_hint", "user@example.com")
 
-	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
 	query := mustParseRedirectQuery(t, redirect)
 
 	if query.Get("login_hint") != "user@example.com" {
@@ -307,7 +307,7 @@ func TestPrepareAuthorizationRedirectURLAppendsAdditionalScopes(t *testing.T) {
 	values := url.Values{}
 	values.Set("additional_scopes", "email profile")
 
-	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(values))
 	query := mustParseRedirectQuery(t, redirect)
 
 	if query.Get("scope") != "identify email profile" {
@@ -316,7 +316,7 @@ func TestPrepareAuthorizationRedirectURLAppendsAdditionalScopes(t *testing.T) {
 }
 
 func TestPrepareAuthorizationRedirectURLUsesAuthorizationCodeCallback(t *testing.T) {
-	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
 	query := mustParseRedirectQuery(t, redirect)
 
 	expected := authorizationSetupTestReqPath + "/authorization-code-callback"
@@ -326,7 +326,7 @@ func TestPrepareAuthorizationRedirectURLUsesAuthorizationCodeCallback(t *testing
 }
 
 func TestPrepareAuthorizationRedirectURLUsesJSCallbackWhenEnabled(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.config.JsCallbackEnabled = true
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -339,7 +339,7 @@ func TestPrepareAuthorizationRedirectURLUsesJSCallbackWhenEnabled(t *testing.T) 
 }
 
 func TestPrepareAuthorizationRedirectURLOmitsScopeWhenDisabled(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableScope = true
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -351,7 +351,7 @@ func TestPrepareAuthorizationRedirectURLOmitsScopeWhenDisabled(t *testing.T) {
 }
 
 func TestPrepareAuthorizationRedirectURLOmitsResponseTypeWhenDisabled(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableResponseType = true
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -363,7 +363,7 @@ func TestPrepareAuthorizationRedirectURLOmitsResponseTypeWhenDisabled(t *testing
 }
 
 func TestPrepareAuthorizationRedirectURLOmitsNonceWhenDisabled(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disableNonce = true
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -375,7 +375,7 @@ func TestPrepareAuthorizationRedirectURLOmitsNonceWhenDisabled(t *testing.T) {
 }
 
 func TestFinalizeAuthorizationRedirectURLAddsPKCEChallenge(t *testing.T) {
-	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
+	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, newGoogleAuthorizationSetupTestProvider(), parseOAuthAuthenticateRequestParams(url.Values{}))
 	query := mustParseRedirectQuery(t, redirect)
 
 	if query.Get("code_challenge") != authorizationSetupTestPKCE {
@@ -387,7 +387,7 @@ func TestFinalizeAuthorizationRedirectURLAddsPKCEChallenge(t *testing.T) {
 }
 
 func TestFinalizeAuthorizationRedirectURLOmitsPKCEWhenDisabled(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.disablePKCE = true
 
 	redirect := mustPrepareAndFinalizeAuthorizationRedirect(t, provider, parseOAuthAuthenticateRequestParams(url.Values{}))
@@ -402,7 +402,7 @@ func TestFinalizeAuthorizationRedirectURLOmitsPKCEWhenDisabled(t *testing.T) {
 }
 
 func TestPrepareAuthorizationRedirectURLReturnsConfigErrorBeforePKCESetup(t *testing.T) {
-	provider := newAuthorizationSetupTestProvider()
+	provider := newGoogleAuthorizationSetupTestProvider()
 	provider.authorizationURL = "https://domain/oauth/authorize?prompt=none" + string(byte(1))
 
 	_, err := provider.prepareAuthorizationRedirectURL(

--- a/pkg/idp/oauth/authenticate_test.go
+++ b/pkg/idp/oauth/authenticate_test.go
@@ -75,16 +75,40 @@ func TestAuthenticate(t *testing.T) {
 					"response_type=code&scope=identify&state=52fdfc07-2182-454f-963f-5f0f9a621d72",
 			},
 		},
-		// Verify request-time prompt is forwarded to the authorization redirect.
 		{
-			name: "discord provider forwards request prompt",
+			name: "discord provider forwards request prompt none",
 			config: &Config{
 				Name:             "discord",
 				Realm:            "discord",
 				Driver:           "discord",
 				ClientID:         "foo",
 				ClientSecret:     "bar",
-				AuthorizationURL: "https://discordapp.com/other/authorize?prompt=none",
+				AuthorizationURL: "https://discordapp.com/other/authorize",
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=none", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&prompt=none&" +
+					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+			},
+		},
+		{
+			name: "discord provider forwards request prompt consent",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize",
 			},
 			logger: logutil.NewLogger(),
 			request: requests.Request{
@@ -96,9 +120,59 @@ func TestAuthenticate(t *testing.T) {
 			},
 			want: requests.Response{
 				Code: 302,
-				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&prompt=consent&" +
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
+					"prompt=consent&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=81855ad8-681d-4d86-91e9-1e00167939cb",
+			},
+		},
+		{
+			name: "discord provider forwards request prompt select_account",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize",
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=select_account", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
+					"prompt=select_account&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=6694d2c4-22ac-4208-a007-2939487f6999",
+			},
+		},
+		{
+			name: "discord provider drops invalid request prompt",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize",
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=bogus", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
 					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
-					"response_type=code&scope=identify&state=9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+					"response_type=code&scope=identify&state=eb9d18a4-4784-445d-87f3-c67cf22746e9",
 			},
 		},
 		{

--- a/pkg/idp/oauth/authenticate_test.go
+++ b/pkg/idp/oauth/authenticate_test.go
@@ -217,6 +217,64 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
+			name: "google provider forwards request prompt consent and select account",
+			config: &Config{
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=consent+select_account", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
+					"prompt=consent+select_account&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=5fb90bad-b37c-4821-b6d9-5526a41a9504",
+			},
+		},
+		{
+			name: "google provider forwards request prompt select account and consent",
+			config: &Config{
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=select_account+consent", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
+					"prompt=select_account+consent&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=680b4e7c-8b76-4a1b-9d49-d4955c848621",
+			},
+		},
+		{
 			name: "discord provider with overridden and invalid urls",
 			config: &Config{
 				Name:             "discord",

--- a/pkg/idp/oauth/authenticate_test.go
+++ b/pkg/idp/oauth/authenticate_test.go
@@ -75,6 +75,32 @@ func TestAuthenticate(t *testing.T) {
 					"response_type=code&scope=identify&state=52fdfc07-2182-454f-963f-5f0f9a621d72",
 			},
 		},
+		// Verify request-time prompt is forwarded to the authorization redirect.
+		{
+			name: "discord provider forwards request prompt",
+			config: &Config{
+				Name:             "discord",
+				Realm:            "discord",
+				Driver:           "discord",
+				ClientID:         "foo",
+				ClientSecret:     "bar",
+				AuthorizationURL: "https://discordapp.com/other/authorize?prompt=none",
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=consent", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&prompt=consent&" +
+					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=9566c74d-1003-4c4d-bbbb-0407d1e2c649",
+			},
+		},
 		{
 			name: "discord provider with overridden and invalid urls",
 			config: &Config{

--- a/pkg/idp/oauth/authenticate_test.go
+++ b/pkg/idp/oauth/authenticate_test.go
@@ -76,7 +76,7 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			name: "discord provider forwards request prompt none",
+			name: "discord provider ignores request prompt none",
 			config: &Config{
 				Name:             "discord",
 				Realm:            "discord",
@@ -95,20 +95,53 @@ func TestAuthenticate(t *testing.T) {
 			},
 			want: requests.Response{
 				Code: 302,
-				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&prompt=none&" +
+				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
 					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
 					"response_type=code&scope=identify&state=9566c74d-1003-4c4d-bbbb-0407d1e2c649",
 			},
 		},
 		{
-			name: "discord provider forwards request prompt consent",
+			name: "google provider forwards request prompt none",
 			config: &Config{
-				Name:             "discord",
-				Realm:            "discord",
-				Driver:           "discord",
-				ClientID:         "foo",
-				ClientSecret:     "bar",
-				AuthorizationURL: "https://discordapp.com/other/authorize",
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
+			},
+			logger: logutil.NewLogger(),
+			request: requests.Request{
+				Upstream: requests.Upstream{
+					BaseURL:  "https://hostname",
+					BasePath: "/route",
+					Request:  must(http.NewRequest(http.MethodGet, "/foo?bar=baz&prompt=none", nil)),
+				},
+			},
+			want: requests.Response{
+				Code: 302,
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
+					"prompt=none&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
+					"response_type=code&scope=identify&state=81855ad8-681d-4d86-91e9-1e00167939cb",
+			},
+		},
+		{
+			name: "google provider forwards request prompt consent",
+			config: &Config{
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
 			},
 			logger: logutil.NewLogger(),
 			request: requests.Request{
@@ -120,20 +153,24 @@ func TestAuthenticate(t *testing.T) {
 			},
 			want: requests.Response{
 				Code: 302,
-				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
 					"prompt=consent&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
-					"response_type=code&scope=identify&state=81855ad8-681d-4d86-91e9-1e00167939cb",
+					"response_type=code&scope=identify&state=6694d2c4-22ac-4208-a007-2939487f6999",
 			},
 		},
 		{
-			name: "discord provider forwards request prompt select_account",
+			name: "google provider forwards request prompt select_account",
 			config: &Config{
-				Name:             "discord",
-				Realm:            "discord",
-				Driver:           "discord",
-				ClientID:         "foo",
-				ClientSecret:     "bar",
-				AuthorizationURL: "https://discordapp.com/other/authorize",
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
 			},
 			logger: logutil.NewLogger(),
 			request: requests.Request{
@@ -145,20 +182,24 @@ func TestAuthenticate(t *testing.T) {
 			},
 			want: requests.Response{
 				Code: 302,
-				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
 					"prompt=select_account&redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
-					"response_type=code&scope=identify&state=6694d2c4-22ac-4208-a007-2939487f6999",
+					"response_type=code&scope=identify&state=eb9d18a4-4784-445d-87f3-c67cf22746e9",
 			},
 		},
 		{
-			name: "discord provider drops invalid request prompt",
+			name: "google provider drops invalid request prompt",
 			config: &Config{
-				Name:             "discord",
-				Realm:            "discord",
-				Driver:           "discord",
-				ClientID:         "foo",
-				ClientSecret:     "bar",
-				AuthorizationURL: "https://discordapp.com/other/authorize",
+				Name:                    "google",
+				Realm:                   "google",
+				Driver:                  "google",
+				ClientID:                "foo.apps.googleusercontent.com",
+				ClientSecret:            "bar",
+				Scopes:                  []string{"identify"},
+				AuthorizationURL:        "https://accounts.google.com/o/oauth2/v2/auth",
+				KeyVerificationDisabled: true,
+				NonceDisabled:           true,
+				PKCEDisabled:            true,
 			},
 			logger: logutil.NewLogger(),
 			request: requests.Request{
@@ -170,9 +211,9 @@ func TestAuthenticate(t *testing.T) {
 			},
 			want: requests.Response{
 				Code: 302,
-				RedirectURL: "https://discordapp.com/other/authorize?client_id=foo&" +
+				RedirectURL: "https://accounts.google.com/o/oauth2/v2/auth?client_id=foo.apps.googleusercontent.com&" +
 					"redirect_uri=https%3A%2F%2Fhostname%2Froute%2Fauthorization-code-callback&" +
-					"response_type=code&scope=identify&state=eb9d18a4-4784-445d-87f3-c67cf22746e9",
+					"response_type=code&scope=identify&state=95af5a25-3679-41ba-a2ff-6cd471c483f1",
 			},
 		},
 		{


### PR DESCRIPTION
# Description

This parameter allows you to force Google Auth to always ask for the account name.  This is useful in Google Chrome where Chrome will use an existing already authenticated Chrome session instead of asking which session to use.

Without this parameter, switching to another authenticated Google account can require manual intervention (such as deleting cookies).

# Details

I'm using Caddy to protect a web service I am hosting with a list of allowed Google Accounts.  I ran into a problem in Google Chrome where Chrome was not asking which account I wanted to use.  It assumed I always wanted to use the default logged in browser session.

I did a little research and found that I could use the `prompt=select_account`, example:

```
set auth url https://DOMAIN/oauth2/google?prompt=select_account
```

to force Google to always ask which account I wanted to use for authentication.  Unfortunately this parameter was not allowed by the current code.

This is my attempt at enabling support for this parameter.  I have already patched go-authcrunch in my local Caddy installation and it fixes the problem for me.  