### PR TITLE
fix: dead bcrypt hash equality check

### DIFF
--- a/pkg/identity/user.go
+++ b/pkg/identity/user.go
@@ -163,7 +163,7 @@ func (user *User) AddPassword(s string, keepVersions int) error {
 
 	// Check if the existing password is the same as the one provided.
 	if len(user.Passwords) > 0 {
-		if user.Passwords[0].Hash == password.Hash {
+		if user.Passwords[0].Match(s) {
 			return nil
 		}
 	}

--- a/pkg/identity/user_test.go
+++ b/pkg/identity/user_test.go
@@ -15,8 +15,9 @@
 package identity
 
 import (
-	"github.com/greenpau/go-authcrunch/pkg/requests"
 	"testing"
+
+	"github.com/greenpau/go-authcrunch/pkg/requests"
 )
 
 func TestNewUser(t *testing.T) {
@@ -27,6 +28,14 @@ func TestNewUser(t *testing.T) {
 
 	if err := user.AddPassword("jsmith123", 0); err != nil {
 		t.Fatalf("error adding password: %s", err)
+	}
+
+	// no-op when adding the same password
+	if err := user.AddPassword("jsmith123", 0); err != nil {
+		t.Fatalf("error adding duplicate password: %s", err)
+	}
+	if len(user.Passwords) != 1 {
+		t.Fatalf("expected 1 password after duplicate add, got %d", len(user.Passwords))
 	}
 
 	if err := user.Valid(); err != nil {
@@ -69,4 +78,38 @@ func TestNewUser(t *testing.T) {
 		t.Fatalf("expected 0 public keys")
 	}
 
+}
+
+func TestAddPasswordSame(t *testing.T) {
+	user := NewUser("jsmith")
+	if err := user.AddPassword("jsmith123", 0); err != nil {
+		t.Fatalf("first AddPassword failed: %s", err)
+	}
+	firstHash := user.Passwords[0].Hash
+
+	if err := user.AddPassword("jsmith123", 0); err != nil {
+		t.Fatalf("duplicate AddPassword failed: %s", err)
+	}
+	if len(user.Passwords) != 1 {
+		t.Fatalf("expected 1 password, got %d", len(user.Passwords))
+	}
+	if user.Passwords[0].Hash != firstHash {
+		t.Fatalf("expected same hash on duplicate add, got different one")
+	}
+}
+
+func TestAddPasswordDifferent(t *testing.T) {
+	user := NewUser("jsmith")
+	if err := user.AddPassword("jsmith123", 0); err != nil {
+		t.Fatalf("first AddPassword failed: %s", err)
+	}
+	if err := user.AddPassword("newpass456", 0); err != nil {
+		t.Fatalf("second AddPassword failed: %s", err)
+	}
+	if len(user.Passwords) != 2 {
+		t.Fatalf("expected 2 passwords, got %d", len(user.Passwords))
+	}
+	if !user.Passwords[1].Disabled {
+		t.Fatalf("expected old password to be disabled")
+	}
 }


### PR DESCRIPTION
This PR should fix #95, by replacing equality by a Match function.
One side effect is that `AddPassword` becomes a no-op when the same password is set.
If the user expects the same password to create a different hash, this would prevent that.