### PR TITLE
fix: canonicalize URL path in bypass.Match to prevent path traversal

### DIFF
--- a/pkg/authz/bypass/bypass.go
+++ b/pkg/authz/bypass/bypass.go
@@ -75,27 +75,27 @@ func (b *Config) Validate() error {
 
 // Match matches HTTP URL to the bypass configuration.
 func Match(r *http.Request, cfgs []*Config) bool {
-	cleanedPath := path.Clean(r.URL.Path)
+	sanitizedPath := path.Clean(r.URL.Path)
 	for _, cfg := range cfgs {
 		switch cfg.match {
 		case bypassMatchExact:
-			if cfg.URI == cleanedPath {
+			if cfg.URI == sanitizedPath {
 				return true
 			}
 		case bypassMatchPartial:
-			if strings.Contains(cleanedPath, cfg.URI) {
+			if strings.Contains(sanitizedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchPrefix:
-			if strings.HasPrefix(cleanedPath, cfg.URI) {
+			if strings.HasPrefix(sanitizedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchSuffix:
-			if strings.HasSuffix(cleanedPath, cfg.URI) {
+			if strings.HasSuffix(sanitizedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchRegex:
-			if cfg.regex.MatchString(cleanedPath) {
+			if cfg.regex.MatchString(sanitizedPath) {
 				return true
 			}
 		}

--- a/pkg/authz/bypass/bypass.go
+++ b/pkg/authz/bypass/bypass.go
@@ -17,6 +17,7 @@ package bypass
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 )
@@ -74,26 +75,27 @@ func (b *Config) Validate() error {
 
 // Match matches HTTP URL to the bypass configuration.
 func Match(r *http.Request, cfgs []*Config) bool {
+	cleanedPath := path.Clean(r.URL.Path)
 	for _, cfg := range cfgs {
 		switch cfg.match {
 		case bypassMatchExact:
-			if cfg.URI == r.URL.Path {
+			if cfg.URI == cleanedPath {
 				return true
 			}
 		case bypassMatchPartial:
-			if strings.Contains(r.URL.Path, cfg.URI) {
+			if strings.Contains(cleanedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchPrefix:
-			if strings.HasPrefix(r.URL.Path, cfg.URI) {
+			if strings.HasPrefix(cleanedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchSuffix:
-			if strings.HasSuffix(r.URL.Path, cfg.URI) {
+			if strings.HasSuffix(cleanedPath, cfg.URI) {
 				return true
 			}
 		case bypassMatchRegex:
-			if cfg.regex.MatchString(r.URL.Path) {
+			if cfg.regex.MatchString(cleanedPath) {
 				return true
 			}
 		}

--- a/pkg/authz/bypass/bypass_test.go
+++ b/pkg/authz/bypass/bypass_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bypass
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestMatchPathTraversal(t *testing.T) {
+	cfgs := []*Config{
+		{
+			MatchType: "prefix",
+			URI:       "/public/",
+		},
+	}
+	for _, cfg := range cfgs {
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("failed to validate config: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "legitimate public path matches",
+			path: "/public/assets/style.css",
+			want: true,
+		},
+		{
+			name: "non-public path does not match",
+			path: "/admin/dashboard",
+			want: false,
+		},
+		{
+			name: "path traversal out of public must not match",
+			path: "/public/../../admin",
+			want: false,
+		},
+		{
+			name: "encoded traversal must not match",
+			path: "/public/../../../etc/passwd",
+			want: false,
+		},
+		{
+			name: "dot segment at end cleaned correctly",
+			path: "/public/./file.txt",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{
+				URL: &url.URL{Path: tt.path},
+			}
+			got := Match(r, cfgs)
+			if got != tt.want {
+				t.Errorf("Match(path=%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the fix I mentioned in my email on June 11 — bypass.Match() uses r.URL.Path directly for string matching without calling path.Clean first.

Go's net/http decodes percent-encoding in the request URI but doesn't resolve dot segments. So a request to `/public/..%2f..%2fadmin` arrives with r.URL.Path set to `/public/../../admin`. The prefix check passes against `/public/` and the gatekeeper returns Bypassed=true, skipping all token validation and ACL checks.

**What this PR does:**

- Adds `path.Clean(r.URL.Path)` at the top of Match() before the matching loop
- All five match types (exact, partial, prefix, suffix, regex) now operate on the cleaned path
- Adds test cases covering traversal rejection and legitimate path matching

`path.Clean` resolves `..` and `.` segments and collapses multiple slashes — standard defense against this class of bypass. For reference, Authelia does the same thing with their `URLPathFullClean()` before ACL matching.

The fix is minimal and only touches the bypass matching logic. No changes to the gatekeeper, authenticate flow, or any other package.